### PR TITLE
[Test] Overhauled prespecialized-metadata/*.

### DIFF
--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,13 +9,13 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -25,57 +24,27 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   i8*, 
-//         CHECK-SAME:   %swift.type*, 
-// CHECK-unknown-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+// CHECK-unknown-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
 // CHECK-unknown-SAME:   [[INT]], 
-//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.type*
-//         CHECK-SAME:   )* 
+//   CHECK-apple-SAME:   ptr
 //         CHECK-SAME: }> <{ 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
+//         CHECK-SAME:   ptr
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMM
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null, 
 //   CHECK-apple-SAME:   [[INT]] add (
-//   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             2 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf" to [[INT]]
-//   CHECK-apple-SAME:     ), 
+//   CHECK-apple-SAME:     ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf"{{[^,]*}} to [[INT]]
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
 // CHECK-unknown-SAME:  [[INT]] 0, 
-// CHECK-unknown-SAME:  %swift.type* null, 
+// CHECK-unknown-SAME:  ptr null, 
 //         CHECK-SAME:   i32 26, 
 //         CHECK-SAME:   i32 0, 
 //         CHECK-SAME:   i32 {{(32|16)}}, 
@@ -84,109 +53,22 @@
 //   CHECK-apple-SAME:   i32 {{(144|84)}}, 
 // CHECK-unknown-SAME:   i32 120,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument2[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument2[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
 //         CHECK-SAME:   [[INT]] {{(24|12)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -227,29 +109,22 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Argument1(value: 13), second: Argument2(value: "13")) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
-//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -259,50 +134,15 @@ doit()
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument2[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 // CHECK-unknown:  ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :    %objc_class* bitcast (
-//              :      %swift.type* getelementptr inbounds (
-//              :        %swift.full_heapmetadata,
-//              :        %swift.full_heapmetadata* bitcast (
-//              :          <{
-//              :            void (
-//              :              %T4main5Value[[UNIQUE_ID_1]]LLC*
-//              :            )*,
-//              :            i8**,
-//              :            [[INT]],
-//              :            %objc_class*,
-//              :            %swift.opaque*,
-//              :            %swift.opaque*,
-//              :            [[INT]],
-//              :            i32,
-//              :            i32,
-//              :            i32,
-//              :            i16,
-//              :            i16,
-//              :            i32,
-//              :            i32,
-//              :            %swift.type_descriptor*,
-//              :            i8*,
-//              :            %swift.type*,
-//              :            %swift.type*,
-//              :            [[INT]],
-//              :            [[INT]],
-//              :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//              :              %swift.opaque*,
-//              :              %swift.opaque*,
-//              :              %swift.type*
-//              :            )*
-//              :          }>* 
-//    CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf" 
-//              :          to %swift.full_heapmetadata*
-//              :        ),
-//              :        i32 0,
-//              :        i32 2
-//              :      ) to %objc_class*
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//              :   ptr getelementptr inbounds (
+//              :     %swift.full_heapmetadata,
+// CHECK-SAME:        $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf
+//              :     i32 0,
+//              :     i32 2
 //              :    )
 //              :  )
-//   CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,13 +9,13 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -25,55 +24,27 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   i8*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
-//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.type*
-//         CHECK-SAME:   )* 
+//   CHECK-apple-SAME:   ptr 
 //         CHECK-SAME: }> <{ 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
+//         CHECK-SAME:   ptr 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMM
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null, 
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             2 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
-// CHECK-unknown-SAME:  [[INT]] 0, 
-// CHECK-unknown-SAME:  %swift.type* null, 
+// CHECK-unknown-SAME:   [[INT]] 0, 
+// CHECK-unknown-SAME:   ptr null, 
 //         CHECK-SAME:   i32 26, 
 //         CHECK-SAME:   i32 0, 
 //         CHECK-SAME:   i32 {{(32|16)}}, 
@@ -82,109 +53,22 @@
 //   CHECK-apple-SAME:   i32 {{(144|84)}}, 
 // CHECK-unknown-SAME:   i32 120,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
 //         CHECK-SAME:   [[INT]] {{(24|12)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -217,29 +101,22 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Argument1(value: 13), second: Argument1(value: "13")) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
-//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -249,50 +126,17 @@ doit()
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 // CHECK-unknown:  ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :    %objc_class* bitcast (
-//              :      %swift.type* getelementptr inbounds (
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//              :    ptr bitcast (
+//              :      ptr getelementptr inbounds (
 //              :        %swift.full_heapmetadata,
-//              :        %swift.full_heapmetadata* bitcast (
-//              :          <{
-//              :            void (
-//              :              %T4main5Value[[UNIQUE_ID_1]]LLC*
-//              :            )*,
-//              :            i8**,
-//              :            [[INT]],
-//              :            %objc_class*,
-//              :            %swift.opaque*,
-//              :            %swift.opaque*,
-//              :            [[INT]],
-//              :            i32,
-//              :            i32,
-//              :            i32,
-//              :            i16,
-//              :            i16,
-//              :            i32,
-//              :            i32,
-//              :            %swift.type_descriptor*,
-//              :            i8*,
-//              :            %swift.type*,
-//              :            %swift.type*,
-//              :            [[INT]],
-//              :            [[INT]],
-//              :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//              :              %swift.opaque*,
-//              :              %swift.opaque*,
-//              :              %swift.type*
-//              :            )*
-//              :          }>* 
-//    CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" 
-//              :          to %swift.full_heapmetadata*
-//              :        ),
+//    CHECK-SAME:        $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf
 //              :        i32 0,
 //              :        i32 2
-//              :      ) to %objc_class*
+//              :      ) to ptr
 //              :    )
 //              :  )
-//   CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,13 +9,13 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -25,55 +24,26 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   i8*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
-//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.opaque*, 
-//   CHECK-apple-SAME:     %swift.type*
-//         CHECK-SAME:   )* 
+//   CHECK-apple-SAME:   ptr 
 //         CHECK-SAME: }> <{ 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]LLC*)* 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMM
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   null, 
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             2 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf" to [[INT]]
+//   CHECK-apple-SAME:     ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
 // CHECK-unknown-SAME:  [[INT]] 0, 
-// CHECK-unknown-SAME:  %swift.type* null, 
+// CHECK-unknown-SAME:  ptr null, 
 //         CHECK-SAME:   i32 26, 
 //         CHECK-SAME:   i32 0, 
 //         CHECK-SAME:   i32 {{(32|16)}}, 
@@ -82,109 +52,22 @@
 //   CHECK-apple-SAME:   i32 {{(144|84)}}, 
 // CHECK-unknown-SAME:   i32 120,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main9Argument1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
 //         CHECK-SAME:   [[INT]] {{(24|12)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5first6secondADyxq_Gx_q_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -217,29 +100,24 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Argument1(value: 13), second: Argument1(value: 13)) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT1_METADATA:%[0-9]+]], %swift.type* [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_ARGUMENT1:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT1_METADATA]] to i8*
-//      CHECK:   [[ERASED_ARGUMENT2:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT2_METADATA]] to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT1]], 
-//      CHECK:     i8* [[ERASED_ARGUMENT2]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMz
+//      CHECK:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -249,50 +127,17 @@ doit()
 //             CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //         CHECK-NOT:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //     CHECK-unknown:  ret
-//       CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                  :    %objc_class* bitcast (
-//                  :      %swift.type* getelementptr inbounds (
+//       CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//                  :    ptr bitcast (
+//                  :      ptr getelementptr inbounds (
 //                  :        %swift.full_heapmetadata,
-//                  :        %swift.full_heapmetadata* bitcast (
-//                  :          <{
-//                  :            void (
-//                  :              %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                  :            )*,
-//                  :            i8**,
-//                  :            [[INT]],
-//                  :            %objc_class*,
-//                  :            %swift.opaque*,
-//                  :            %swift.opaque*,
-//                  :            [[INT]],
-//                  :            i32,
-//                  :            i32,
-//                  :            i32,
-//                  :            i16,
-//                  :            i16,
-//                  :            i32,
-//                  :            i32,
-//                  :            %swift.type_descriptor*,
-//                  :            i8*,
-//                  :            %swift.type*,
-//                  :            %swift.type*,
-//                  :            [[INT]],
-//                  :            [[INT]],
-//                  :            %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                  :              %swift.opaque*,
-//                  :              %swift.opaque*,
-//                  :              %swift.type*
-//                  :            )*
-//                  :          }>* 
-//        CHECK-SAME:          @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf" 
-//                  :          to %swift.full_heapmetadata*
-//                  :        ),
+//        CHECK-SAME:        $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf
 //                  :        i32 0,
 //                  :        i32 2
-//                  :      ) to %objc_class*
+//                  :      ) to ptr
 //                  :    )
 //                  :  )
-//       CHECK-apple:  [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//       CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//       CHECK-apple:  [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //       CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //       CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //             CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -13,14 +12,12 @@
 // CHECK-unknown-SAME: constant 
 //   CHECK-apple-SAME: global 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//         CHECK-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//         CHECK-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -29,105 +26,33 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSd*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySSGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
-//                   :   %swift.type* getelementptr inbounds (
+//                   :   ptr getelementptr inbounds (
 //                   :     %swift.full_heapmetadata,
-//                   :     %swift.full_heapmetadata* bitcast (
-//                   :       <{
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
-//                   :         )*,
-//                   :         i8**,
-//                   :         [[INT]],
-//                   :         %swift.type*,
-//                   :         %swift.opaque*,
-//                   :         %swift.opaque*,
-//                   :         [[INT]],
-//                   :         i32,
-//                   :         i32,
-//                   :         i32,
-//                   :         i16,
-//                   :         i16,
-//                   :         i32,
-//                   :         i32,
-//                   :         %swift.type_descriptor*,
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]],
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//                   :           %TSd*,
-//                   :           %swift.type*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]],
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//                   :           %swift.opaque*,
-//                   :           %swift.type*
-//                   :         )*
-//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
-//                   :     ),
+//                   :     $s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf
 //                   :     i32 0,
 //                   :     i32 2
 //                   :   ),
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       {
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//                   :         i32,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             1 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -139,56 +64,16 @@
 //   CHECK-apple-SAME:   i32 {{(176|100)}},
 // CHECK-unknown-SAME:   i32 152,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor,
-//                   :       i32,
-//                   :       %swift.method_override_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSd*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main9Ancestor1[[UNIQUE_ID_1]]C5firstADyxGSd_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(24|16)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor1ACLLCAeHyxGx_tcfCTV
-//         CHECK-SAME:   %swift.type* @"$sSSN", 
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(32|20)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -229,75 +114,62 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: "13") )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+//           :     ptr bitcast (
 //           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
 // CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
+//           :       to ptr
 //           :     )
 // CHECK-SAME:   ) #{{[0-9]+}}
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
 //         CHECK: ; Function Attrs: noinline nounwind readnone
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
 //         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
 //     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
 // CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
 //    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -13,14 +12,12 @@
 // CHECK-unknown-SAME: constant 
 //   CHECK-apple-SAME: global 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//         CHECK-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//         CHECK-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -29,97 +26,32 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySSGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
-//                   :   %swift.type* getelementptr inbounds (
+//                   :   ptr getelementptr inbounds (
 //                   :     %swift.full_heapmetadata,
-//                   :     %swift.full_heapmetadata* bitcast (
-//                   :       <{
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
-//                   :         )*,
-//                   :         i8**,
-//                   :         [[INT]],
-//                   :         %swift.type*,
-//                   :         %swift.opaque*,
-//                   :         %swift.opaque*,
-//                   :         [[INT]],
-//                   :         i32,
-//                   :         i32,
-//                   :         i32,
-//                   :         i16,
-//                   :         i16,
-//                   :         i32,
-//                   :         i32,
-//                   :         %swift.type_descriptor*,
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]C*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]],
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//                   :           %swift.opaque*,
-//                   :           %swift.type*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]]
-//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
-//                   :     ),
+//                   :     $s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf
 //                   :     i32 0,
 //                   :     i32 2
 //                   :   ),
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       {
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//                   :         i32,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             1 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -131,49 +63,15 @@
 //   CHECK-apple-SAME:   i32 {{(168|96)}},
 // CHECK-unknown-SAME:   i32 144,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       %swift.method_override_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(24|12)}},
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(32|16)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -214,62 +112,47 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: "13") )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
-//           :     )
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor2[[UNIQUE_ID_1]]CMn
 // CHECK-SAME:   ) #{{[0-9]+}}
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]CMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -279,10 +162,9 @@ doit()
 //         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
 //     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
 // CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
 //    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -13,14 +12,12 @@
 // CHECK-unknown-SAME: constant 
 //   CHECK-apple-SAME: global 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//         CHECK-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//         CHECK-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -29,101 +26,32 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]]
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCySSGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
-//                   :   %swift.type* getelementptr inbounds (
+//                   :   ptr getelementptr inbounds (
 //                   :     %swift.full_heapmetadata,
-//                   :     %swift.full_heapmetadata* bitcast (
-//                   :       <{
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :         )*,
-//                   :         i8**,
-//                   :         [[INT]],
-//                   :         %swift.type*,
-//                   :         %swift.opaque*,
-//                   :         %swift.opaque*,
-//                   :         [[INT]],
-//                   :         i32,
-//                   :         i32,
-//                   :         i32,
-//                   :         i16,
-//                   :         i16,
-//                   :         i32,
-//                   :         i32,
-//                   :         %swift.type_descriptor*,
-//                   :         void (
-//                   :           %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]],
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :           %TSi*,
-//                   :           %swift.type*
-//                   :         )*,
-//                   :         %swift.type*,
-//                   :         [[INT]],
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :           %swift.opaque*,
-//                   :           %swift.type*
-//                   :         )*
-//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
-//                   :     ),
+//                   :     $s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf
 //                   :     i32 0,
 //                   :     i32 2
 //                   :   ),
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       {
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//                   :         i32,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             1 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -135,49 +63,15 @@
 //   CHECK-apple-SAME:   i32 {{(168|96)}},
 // CHECK-unknown-SAME:   i32 144,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       %swift.method_override_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                   :   $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfE
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %TSi*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main9Ancestor1[[UNIQUE_ID_1]]LLC5firstADyxGSi_tcfCAA9Ancestor2ACLLCAeHyxGx_tcfCTV
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(24|12)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
-//         CHECK-SAME:   %swift.type* @"$sSSN",
+//         CHECK-SAME:   $sSSN
 //         CHECK-SAME:   [[INT]] {{(40|24)}}
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -218,62 +112,47 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: "13") )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor2[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -283,10 +162,9 @@ doit()
 //         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 //     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 // CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
 //    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" 
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -13,14 +12,12 @@
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -29,93 +26,31 @@
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCySiGMM
 // CHECK-unknown-SAME: [[INT]] 0,
-//                   :  %swift.type* getelementptr inbounds (
+//                   :  ptr getelementptr inbounds (
 //                   :    %swift.full_heapmetadata,
-//                   :    %swift.full_heapmetadata* bitcast (
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        %swift.type_descriptor*,
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        %swift.type*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :          %swift.opaque*,
-//                   :          %swift.type*
-//                   :        )*,
-//                   :        %swift.type*,
-//                   :        [[INT]]
-//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//                   :    ),
+//                   :    $s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMf
 //                   :    i32 0,
 //                   :    i32 2
 //                   :  ),
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
 //   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
+//   CHECK-apple-SAME:      ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
@@ -127,45 +62,14 @@
 //   CHECK-apple-SAME:  i32 {{(160|92)}},
 // CHECK-unknown-SAME:  i32 136,
 //         CHECK-SAME:  i32 {{(24|12)}},
-//                   :  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
-//                   :  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                   :  $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{(16|8)}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{(24|12)}},
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{(32|16)}}
 //         CHECK-SAME:}>,
 //         CHECK-SAME:align [[ALIGNMENT]]
@@ -206,62 +110,47 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor2[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr [[ARGUMENT]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor2[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr [[ARGUMENT]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[ARGUMENT]] to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-//           :     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, %swift.method_override_descriptor }>* 
-// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//           :       to %swift.type_descriptor*
-//           :     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr [[ARGUMENT]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -271,10 +160,9 @@ doit()
 //         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 // CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" 
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -12,14 +11,12 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -28,92 +25,30 @@
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:    %TSi*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*
+//         CHECK-SAME:  ptr
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]CySSGMM
 // CHECK-unknown-SAME:  [[INT]] 0,
-//                   :  %swift.type* getelementptr inbounds (
+//                   :  ptr getelementptr inbounds (
 //                   :    %swift.full_heapmetadata,
-//                   :    %swift.full_heapmetadata* bitcast (
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]C*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %objc_class*,
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        %swift.type_descriptor*,
-//                   :        i8*,
-//                   :        %swift.type*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]C* (
-//                   :          %swift.opaque*,
-//                   :          %swift.type*
-//                   :        )*
-//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to %swift.full_heapmetadata*
-//                   :    ),
+//                   :    $s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf
 //                   :    i32 0,
 //                   :    i32 2
 //                   :  ),
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
 //   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
@@ -125,50 +60,13 @@
 //   CHECK-apple-SAME:  i32 {{(152|88)}},
 // CHECK-unknown-SAME:  i32 128,
 //         CHECK-SAME:  i32 {{(24|12)}},
-//                   :  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      i32,
-//                   :      %swift.method_descriptor,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
-//                   :  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]C*
+//                   :     $s4main5Value[[UNIQUE_ID_1]]CMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]CfE
-//         CHECK-SAME:  %swift.type* @"$sSSN",
+//         CHECK-SAME:  $sSSN
 //         CHECK-SAME:  [[INT]] {{(16|8)}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:    %TSi*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGSi_tcfCAA9Ancestor1ACLLCAeHyxGx_tcfCTV
-//         CHECK-SAME:  %swift.type* @"$sSSN",
+//         CHECK-SAME:  $sSSN
 //         CHECK-SAME:  [[INT]] {{(24|12)}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME:}>,
 //         CHECK-SAME:align [[ALIGNMENT]]
@@ -208,59 +106,13 @@ doit()
 
 //              CHECK: ; Function Attrs: noinline nounwind readnone
 //              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK-NEXT: entry:
 //              CHECK:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
 //      CHECK-unknown:  ret
-//        CHECK-apple:  [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                   :   %objc_class* bitcast (
-//                   :     %swift.type* getelementptr inbounds (
-//                   :       %swift.full_heapmetadata,
-//                   :       %swift.full_heapmetadata* bitcast (
-//                   :         <{
-//                   :           void (
-//                   :             %T4main5Value[[UNIQUE_ID_1]]C*
-//                   :           )*,
-//                   :           i8**,
-//                   :           i64,
-//                   :           %swift.type*,
-//                   :           %swift.opaque*,
-//                   :           %swift.opaque*,
-//                   :           i64,
-//                   :           i32,
-//                   :           i32,
-//                   :           i32,
-//                   :           i16,
-//                   :           i16,
-//                   :           i32,
-//                   :           i32,
-//                   :           %swift.type_descriptor*,
-//                   :           void (
-//                   :             %T4main5Value[[UNIQUE_ID_1]]C*
-//                   :           )*,
-//                   :           %swift.type*,
-//                   :           i64,
-//                   :           %T4main5Value[[UNIQUE_ID_1]]C* (
-//                   :             %TSi*,
-//                   :             %swift.type*
-//                   :           )*,
-//                   :           %swift.type*,
-//                   :           i64,
-//                   :           %T4main5Value[[UNIQUE_ID_1]]C* (
-//                   :             %swift.opaque*,
-//                   :             %swift.type*
-//                   :           )*
-//                   :         }>* 
-//         CHECK-SAME:         @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
-//                   :         to %swift.full_heapmetadata*
-//                   :       ),
-//                   :       i32 0,
-//                   :       i32 2
-//                   :     ) to %objc_class*
-//                   :   )
-//                   : )
-//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
-//        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response %5, [[INT]] 0, 1
+//        CHECK-apple:  [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CySSGMf
+//                   :  )
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
+//        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,12 +9,12 @@
 //   CHECK-apple: global 
 // CHECK-unknown: constant 
 //              : <{ 
-//              :   void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)*, 
-//              :   i8**, 
+//              :   ptr, 
+//              :   ptr, 
 //              :   i64, 
-//              :   %objc_class*, 
-//              :   %swift.opaque*, 
-//              :   %swift.opaque*, 
+//              :   ptr, 
+//              :   ptr, 
+//              :   ptr, 
 //              :   i64, 
 //              :   i32, 
 //              :   i32, 
@@ -24,40 +23,23 @@
 //              :   i16, 
 //              :   i32, 
 //              :   i32, 
-//              :   %swift.type_descriptor*, 
-//              :   i8*, 
-//              :   %swift.type*, 
+//              :   ptr, 
+//              :   ptr, 
+//              :   ptr, 
 //              :   i64, 
-//              :   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//              :   ptr (ptr, ptr 
 //              : }> <{ 
-//              :   void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)* 
-//              :   @"$s4main9Ancestor1[[UNIQUE_ID_1]]CfD", 
-//              :   i8** @"$sBoWV", 
+//              :   @"$s4main9Ancestor1[[UNIQUE_ID_1]]CfD",
+//              :   $sBoWV
 //              :   i64 ptrtoint (
-//              :     %objc_class* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMM" to i64
+//              :     ptr @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMM" to [[INT]]
 //              :   ), 
-//              :   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject", 
-//              :   %swift.opaque* @_objc_empty_cache, 
-//              :   %swift.opaque* null, 
+//              :   OBJC_CLASS_$__TtCs12_SwiftObject
+//              :   _objc_empty_cache
+//              :   ptr null, 
 //              :   i64 add (
 //              :     i64 ptrtoint (
-//              :       { 
-//              :         i32, 
-//              :         i32, 
-//              :         i32, 
-//              :         i32, 
-//              :         i8*, 
-//              :         i8*, 
-//              :         i8*, 
-//              :         i8*, 
-//              :         { 
-//              :           i32, 
-//              :           i32, 
-//              :           [1 x { i64*, i8*, i8*, i32, i32 }] 
-//              :         }*, 
-//              :         i8*, 
-//              :         i8* 
-//              :       }* @"_DATA_$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf to i64
+//              :       ptr {{[^@]*}}@"_DATA_$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
 //              :     ), 
 //              :     i64 2
 //              :   ), 
@@ -68,39 +50,10 @@
 //              :   i16 0, 
 //              :   i32 120, 
 //              :   i32 16, 
-//              :   %swift.type_descriptor* bitcast (
-//              :     <{ 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i32, 
-//              :       i16, 
-//              :       i16, 
-//              :       i16, 
-//              :       i16, 
-//              :       i8, 
-//              :       i8, 
-//              :       i8, 
-//              :       i8, 
-//              :       i32, 
-//              :       i32, 
-//              :       %swift.method_descriptor 
-//              :     }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CMn" 
-//              :     to %swift.type_descriptor*
-//              :   ), 
-//              :   i8* null, 
-//              :   %swift.type* @"$sSiN", 
+//              :   $s4main9Ancestor1[[UNIQUE_ID_1]]CMn
+//              :   ptr null, 
+//              :   $sSiN
 //              :   i64 16, 
-//              :   %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
 //              :   @"$s4main9Ancestor1[[UNIQUE_ID_1]]C5firstADyxGx_tcfC" 
 //              : }>, align [[ALIGNMENT]]
 
@@ -109,12 +62,12 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//         CHECK-SAME:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//         CHECK-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -123,69 +76,29 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]] 
 //         CHECK-SAME: }> <{ 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySiGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
-//                   :   %swift.type* getelementptr inbounds (
+//                   :   ptr getelementptr inbounds (
 //                   :     %swift.full_heapmetadata, 
-//                   :     %swift.full_heapmetadata* bitcast (
-//                   :       <{ 
-//                   :         void (%T4main9Ancestor1[[UNIQUE_ID_1]]C*)*, 
-//                   :         i8**, 
-//                   :         [[INT]], 
-//                   :         %objc_class*, 
-//                   :         %swift.type*, 
-//                   :         %swift.opaque*, 
-//                   :         %swift.opaque*, 
-//                   :         [[INT]], 
-//                   :         i32, 
-//                   :         i32, 
-//                   :         i32, 
-//                   :         i16, 
-//                   :         i16, 
-//                   :         i32, 
-//                   :         i32, 
-//                   :         %swift.type_descriptor*, 
-//                   :         i8*, 
-//                   :         %swift.type*, 
-//                   :         [[INT]], 
-//                   :         %T4main9Ancestor1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
-//                   :       }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf" 
-//                   :       to %swift.full_heapmetadata*
-//                   :     ), 
+//                   :     $s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf
 //                   :     i32 0, 
 //                   :     i32 2
 //                   :   ), 
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null, 
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         { 
-//   CHECK-apple-SAME:           i32, 
-//   CHECK-apple-SAME:           i32, 
-//   CHECK-apple-SAME:           [1 x { [[INT]]*, i8*, i8*, i32, i32 }] 
-//   CHECK-apple-SAME:         }*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
@@ -197,41 +110,12 @@
 //   CHECK-apple-SAME:   i32 {{(144|84)}}, 
 // CHECK-unknown-SAME:   i32 120,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{ 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i32, 
-//                   :       %swift.method_override_descriptor 
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" 
-//                   :     to %swift.type_descriptor*
-//                   :   ), 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)* 
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfE
-//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//         CHECK-SAME:   $sSiN
 //         CHECK-SAME:   [[INT]] {{(16|8)}}, 
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
-//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//         CHECK-SAME:   $sSiN
 //         CHECK-SAME:   [[INT]] {{(24|12)}}
 //         CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -265,48 +149,19 @@ func doit() {
 doit()
 
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySiGMb"
-//    CHECK-NEXT: entry:
 //         CHECK:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
-//   CHECK-apple:  [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//   CHECK-apple:    %objc_class* bitcast (
-// CHECK-unknown:    ret
-//              :     %objc_class* bitcast (
-//              :       %swift.type* getelementptr inbounds (
+//   CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+// CHECK-unknown:     ret
+//              :     ptr bitcast (
+//              :       ptr getelementptr inbounds (
 //              :         %swift.full_heapmetadata, 
-//              :         %swift.full_heapmetadata* bitcast (
-//              :           <{ 
-//              :             void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//              :             i8**, 
-//              :             i64, 
-//              :             %swift.type*, 
-//              :             %swift.opaque*, 
-//              :             %swift.opaque*, 
-//              :             i64, 
-//              :             i32, 
-//              :             i32, 
-//              :             i32, 
-//              :             i16, 
-//              :             i16, 
-//              :             i32, 
-//              :             i32, 
-//              :             %swift.type_descriptor*, 
-//              :             void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//              :             %swift.type*, 
-//              :             i64, 
-//              :             %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*, 
-//              :             %swift.type*, 
-//              :             i64 
-//              :           }>* 
-//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CySiGMf" 
-//              :           to %swift.full_heapmetadata*
-//              :         ), 
+//    CHECK-SAME:         $s4main5Value[[UNIQUE_ID_1]]CySiGMf
 //              :         i32 0, 
 //              :         i32 2
-//              :       ) to %objc_class*
+//              :       ) to ptr
 //              :     )
 //              :   )
-//   CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//   CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//   CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
 //   CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -12,14 +11,12 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -28,88 +25,29 @@
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMM
 // CHECK-unknown-SAME:  [[INT]] 0,
-//                   :  %swift.type* getelementptr inbounds (
+//                   :  ptr getelementptr inbounds (
 //                   :    %swift.full_heapmetadata,
-//                   :    %swift.full_heapmetadata* bitcast (
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %objc_class*,
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        %swift.type_descriptor*,
-//                   :        i8*,
-//                   :        %swift.type*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :          %swift.opaque*,
-//                   :          %swift.type*
-//                   :        )*
-//                   :      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMf" to %swift.full_heapmetadata*
-//                   :    ),
+//                   :    $s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMf
 //                   :    i32 0,
 //                   :    i32 2
 //                   :  ),
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
 //   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" to [[INT]]
+//   CHECK-apple-SAME:      ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
@@ -121,106 +59,19 @@
 //   CHECK-apple-SAME:  i32 {{(144|84)}},
 // CHECK-unknown-SAME:  i32 120,
 //   CHECK-apple-SAME:  i32 {{(24|12)}},
-//                   :  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//                   :    }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
-//                   :  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//                   :  $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
-//         CHECK-SAME:  %swift.type* getelementptr inbounds (
+//         CHECK-SAME:  ptr getelementptr inbounds (
 //         CHECK-SAME:    %swift.full_heapmetadata,
-//         CHECK-SAME:    %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:      <{
-//         CHECK-SAME:        void (
-//         CHECK-SAME:          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:        )*,
-//         CHECK-SAME:        i8**,
-//                   :        [[INT]],
-//   CHECK-apple-SAME:        %objc_class*,
-// CHECK-unknown-SAME:        %swift.type*,
-//   CHECK-apple-SAME:        %swift.opaque*,
-//   CHECK-apple-SAME:        %swift.opaque*,
-//   CHECK-apple-SAME:        [[INT]],
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i16,
-//         CHECK-SAME:        i16,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        %swift.type_descriptor*,
-//         CHECK-SAME:        i8*,
-//         CHECK-SAME:        %swift.type*,
-//         CHECK-SAME:        [[INT]],
-//         CHECK-SAME:        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:          %swift.opaque*,
-//         CHECK-SAME:          %swift.type*
-//         CHECK-SAME:        )*
-//         CHECK-SAME:      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:    ),
+//         CHECK-SAME:    $s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf
 //         CHECK-SAME:    i32 0,
 //         CHECK-SAME:    i32 3
 //         CHECK-SAME:  ),
 //         CHECK-SAME:  [[INT]] {{16|8}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
-//         CHECK-SAME:  %swift.type* getelementptr inbounds (
+//         CHECK-SAME:  ptr getelementptr inbounds (
 //         CHECK-SAME:    %swift.full_heapmetadata,
-//         CHECK-SAME:    %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:      <{
-//         CHECK-SAME:        void (
-//         CHECK-SAME:          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:        )*,
-//         CHECK-SAME:        i8**,
-//                   :        [[INT]],
-//   CHECK-apple-SAME:        %objc_class*,
-// CHECK-unknown-SAME:        %swift.type*,
-//   CHECK-apple-SAME:        %swift.opaque*,
-//   CHECK-apple-SAME:        %swift.opaque*,
-//   CHECK-apple-SAME:        [[INT]],
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i16,
-//         CHECK-SAME:        i16,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        i32,
-//         CHECK-SAME:        %swift.type_descriptor*,
-//         CHECK-SAME:        i8*,
-//         CHECK-SAME:        %swift.type*,
-//         CHECK-SAME:        [[INT]],
-//         CHECK-SAME:        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:          %swift.opaque*,
-//         CHECK-SAME:          %swift.type*
-//         CHECK-SAME:        )*
-//         CHECK-SAME:      }>* @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:    ),
+//         CHECK-SAME:    $s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMf
 //         CHECK-SAME:    i32 0,
 //         CHECK-SAME:    i32 3
 //         CHECK-SAME:  ),
@@ -269,50 +120,17 @@ doit()
 //              CHECK:   [[ARGUMENT_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 //              CHECK:   [[SUPER_CLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCyADySSGGMb"([[INT]] 0)
 //      CHECK-unknown:   ret
-//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                   :     %objc_class* bitcast (
-//                   :       %swift.type* getelementptr inbounds (
+//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+//                   :     ptr bitcast (
+//                   :       ptr getelementptr inbounds (
 //                   :         %swift.full_heapmetadata,
-//                   :         %swift.full_heapmetadata* bitcast (
-//                   :           <{
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i8**,
-//                   :             [[INT]],
-//                   :             %swift.type*,
-//                   :             %swift.opaque*,
-//                   :             %swift.opaque*,
-//                   :             [[INT]],
-//                   :             i32,
-//                   :             i32,
-//                   :             i32,
-//                   :             i16,
-//                   :             i16,
-//                   :             i32,
-//                   :             i32,
-//                   :             %swift.type_descriptor*,
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             [[INT]],
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               %swift.opaque*,
-//                   :               %swift.type*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             [[INT]]
-//        CHECK-apple:           }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" 
-//                   :           to %swift.full_heapmetadata*
-//                   :         ),
+//         CHECK-SAME:         $s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf
 //                   :         i32 0,
 //                   :         i32 2
-//                   :       ) to %objc_class*
+//                   :       ) to ptr
 //                   :     )
-//        CHECK-apple:   )
-//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//   CHECK-apple-SAME:   )
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
 //        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/class-open-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -15,14 +14,12 @@ import TestModule
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -31,59 +28,24 @@ import TestModule
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*
+//         CHECK-SAME:  ptr
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  ptr
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:    $s4main5Value[[UNIQUE_ID_1]]LLCySiGMM
 // CHECK-unknown-SAME:  [[INT]] 0,
 //         CHECK-SAME:  $s10TestModule9Ancestor1CN
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
-//   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
-//   CHECK-apple-SAME:    ),
+//   CHECK-apple-SAME:    _DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
 //         CHECK-SAME:  i32 26,
@@ -94,49 +56,12 @@ import TestModule
 //   CHECK-apple-SAME:  i32 {{(144|84)}},
 // CHECK-unknown-SAME:  i32 120,
 //         CHECK-SAME:  i32 {{(24|12)}},
-//         CHECK-SAME:  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      i32,
-//                   :      %swift.method_descriptor,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//         CHECK-SAME:    $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//         CHECK-SAME:  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
 //         CHECK-SAME:  [[INT]] {{16|8}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCyADyxGSicfC
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{24|12}}
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
 //         CHECK-SAME:}>,
 //         CHECK-SAME:align [[ALIGNMENT]]
@@ -167,55 +92,19 @@ doit()
 
 //              CHECK: ; Function Attrs: noinline nounwind readnone
 //              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK-NEXT: entry:
 //              CHECK:   [[SUPERCLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s10TestModule9Ancestor1CMa"([[INT]] 0)
 //      CHECK-unknown:   ret
-//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                   :     %objc_class* bitcast (
-//                   :       %swift.type* getelementptr inbounds (
+//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+//                   :     ptr bitcast (
+//                   :       ptr getelementptr inbounds (
 //                   :         %swift.full_heapmetadata,
-//                   :         %swift.full_heapmetadata* bitcast (
-//                   :           <{
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i8**,
-//                   :             i64,
-//                   :             %swift.type*,
-//                   :             %swift.opaque*,
-//                   :             %swift.opaque*,
-//                   :             i64,
-//                   :             i32,
-//                   :             i32,
-//                   :             i32,
-//                   :             i16,
-//                   :             i16,
-//                   :             i32,
-//                   :             i32,
-//                   :             %swift.type_descriptor*,
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i64,
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               i64,
-//                   :               %swift.type*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             i64,
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               %swift.opaque*,
-//                   :               %swift.type*
-//                   :             )*
-//         CHECK-SAME:           $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
-//                   :         ),
+//         CHECK-SAME:         $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
 //                   :         i32 0,
 //                   :         i32 2
-//                   :       ) to %objc_class*
+//                   :       ) to ptr
 //                   :     )
 //                   :   )
-//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
 //        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -11,14 +10,12 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -27,141 +24,24 @@
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  ptr
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCySiGMM
 // CHECK-unknown-SAME:  [[INT]] 0,
-//                   :  %swift.type* bitcast (
-//                   :    [[INT]]* getelementptr inbounds (
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %objc_class*,
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        <{
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          %swift.method_descriptor
-//                   :        }>*,
-//                   :        i8*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :          [[INT]],
-//                   :          %swift.type*
-//                   :        )*
-//                   :      }>,
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor1[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %objc_class*,
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        <{
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          i32,
-//                   :          %swift.method_descriptor
-//                   :        }>*,
-//                   :        i8*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor1[[UNIQUE_ID_1]]LLC* (
-//                   :          [[INT]],
-//                   :          %swift.type*
-//                   :        )*
-//         CHECK-SAME:      $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMf
-//                   :      i32 0,
-//                   :      i32 2
-//                   :    ) to %swift.type*
-//                   :  ),
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//         CHECK-SAME:  $s4main9Ancestor1[[UNIQUE_ID_1]]LLCMf
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
 //   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
+//   CHECK-apple-SAME:      ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
@@ -173,42 +53,11 @@
 //   CHECK-apple-SAME:  i32 {{(144|84)}},
 // CHECK-unknown-SAME:  i32 120,
 //         CHECK-SAME:  i32 {{(24|12)}},
-//                   :  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//         CHECK-SAME:    $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//         CHECK-SAME:  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
 //         CHECK-SAME:  [[INT]] {{16|8}},
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGSi_tcfC
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGSi_tcfC
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{24|12}}
 //         CHECK-SAME:}>,
 //         CHECK-SAME:align [[ALIGNMENT]]
@@ -253,52 +102,9 @@ doit()
 //         CHECK-NEXT: entry:
 //              CHECK:   [[SUPERCLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"([[INT]] 0)
 //      CHECK-unknown:   ret
-//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                   :     %objc_class* bitcast (
-//                   :       %swift.type* getelementptr inbounds (
-//                   :         %swift.full_heapmetadata,
-//                   :         %swift.full_heapmetadata* bitcast (
-//                   :           <{
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i8**,
-//                   :             i64,
-//                   :             %swift.type*,
-//                   :             %swift.opaque*,
-//                   :             %swift.opaque*,
-//                   :             i64,
-//                   :             i32,
-//                   :             i32,
-//                   :             i32,
-//                   :             i16,
-//                   :             i16,
-//                   :             i32,
-//                   :             i32,
-//                   :             %swift.type_descriptor*,
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i64,
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               i64,
-//                   :               %swift.type*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             i64,
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               %swift.opaque*,
-//                   :               %swift.type*
-//                   :             )*
-//         CHECK-SAME:           $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
-//                   :         ),
-//                   :         i32 0,
-//                   :         i32 2
-//                   :       ) to %objc_class*
-//                   :     )
-//                   :   )
-//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+//         CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
 //        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,12 +9,12 @@
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant
 //                   : <{ 
-//                   :   void (%T4main9Argument1[[UNIQUE_ID_1]]C*)*, 
-//                   :   i8**, 
+//                   :   void (ptr, 
+//                   :   ptr, 
 //                   :   i64, 
-//                   :   %objc_class*, 
-//                   :   %swift.opaque*, 
-//                   :   %swift.opaque*, 
+//                   :   ptr, 
+//                   :   ptr, 
+//                   :   ptr, 
 //                   :   i64, 
 //                   :   i32, 
 //                   :   i32, 
@@ -24,18 +23,18 @@
 //                   :   i16, 
 //                   :   i32, 
 //                   :   i32, 
-//                   :   %swift.type_descriptor*, 
-//                   :   i8*, 
-//                   :   %swift.type*, 
+//                   :   ptr, 
+//                   :   ptr, 
+//                   :   ptr, 
 //                   :   i64, 
-//                   :   %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//                   :   ptr (ptr, ptr 
 //                   : }> <{ 
-//                   :   void (%T4main9Argument1[[UNIQUE_ID_1]]C*)* @"$s4main9Argument1[[UNIQUE_ID_1]]CfD", 
-//                   :   i8** @"$sBoWV", 
-//                   :   i64 ptrtoint (%objc_class* @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMM" to i64), 
-//                   :   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject", 
-//                   :   %swift.opaque* @_objc_empty_cache, 
-//                   :   %swift.opaque* null, 
+//                   :   void (ptr @"$s4main9Argument1[[UNIQUE_ID_1]]CfD", 
+//                   :   $sBoWV
+//                   :   i64 ptrtoint (ptr @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMM" to i64), 
+//                   :   OBJC_CLASS_$__TtCs12_SwiftObject
+//                   :   _objc_empty_cache
+//                   :   ptr null, 
 //                   :   i64 add (
 //                   :     i64 ptrtoint (
 //                   :       { 
@@ -43,17 +42,17 @@
 //                   :         i32, 
 //                   :         i32, 
 //                   :         i32, 
-//                   :         i8*, 
-//                   :         i8*, 
-//                   :         i8*, 
-//                   :         i8*, 
+//                   :         ptr, 
+//                   :         ptr, 
+//                   :         ptr, 
+//                   :         ptr, 
 //                   :         { 
 //                   :           i32, 
 //                   :           i32, 
-//                   :           [1 x { i64*, i8*, i8*, i32, i32 }] 
+//                   :           [1 x { i64*, ptr, ptr, i32, i32 }] 
 //                   :         }*, 
-//                   :         i8*, 
-//                   :         i8* 
+//                   :         ptr, 
+//                   :         ptr 
 //                   :       }* @"_DATA_$s4main9Argument1[[UNIQUE_ID_1]]CySiGMf" to i64
 //                   :     ), 
 //                   :     i64 2
@@ -65,7 +64,7 @@
 //                   :   i16 0, 
 //                   :   i32 120, 
 //                   :   i32 16, 
-//                   :   %swift.type_descriptor* bitcast (
+//                   :   ptr bitcast (
 //                   :     <{ 
 //                   :       i32, 
 //                   :       i32, 
@@ -92,25 +91,25 @@
 //                   :       i32, 
 //                   :       %swift.method_descriptor 
 //                   :     }>* @"$s4main9Argument1[[UNIQUE_ID_1]]CMn" 
-//                   :     to %swift.type_descriptor*
+//                   :     to ptr
 //                   :   ), 
-//                   :   i8* null, 
-//                   :   %swift.type* @"$sSiN", 
+//                   :   ptr null, 
+//                   :   $sSiN
 //                   :   i64 16, 
-//                   :   %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* @"$s4main9Argument1[[UNIQUE_ID_1]]C5firstADyxGx_tcfC" 
+//                   :   ptr (ptr, ptr @"$s4main9Argument1[[UNIQUE_ID_1]]C5firstADyxGx_tcfC" 
 //                   : }>, align 8
 
 //              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf" = linkonce_odr hidden 
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{ 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//   CHECK-SAME-apple:   %objc_class*, 
-// CHECK-SAME-unknown:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-SAME-apple:   ptr, 
+// CHECK-SAME-unknown:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -119,37 +118,21 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   i8*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME: }> <{ 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMM
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null, 
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         { 
-//   CHECK-apple-SAME:           i32, 
-//   CHECK-apple-SAME:           i32, 
-//   CHECK-apple-SAME:           [1 x { [[INT]]*, i8*, i8*, i32, i32 }] 
-//   CHECK-apple-SAME:         }*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
@@ -161,69 +144,15 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}}, 
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{ 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i16, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i8, 
-//                   :       i32, 
-//                   :       i32, 
-//                   :       %swift.method_descriptor 
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
-//                   :   ), 
-//         CHECK-SAME:   i8* null, 
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
+//         CHECK-SAME:   ptr null, 
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata, 
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{ 
-//         CHECK-SAME:         void (%T4main9Argument1[[UNIQUE_ID_1]]C*)*, 
-//         CHECK-SAME:         i8**, 
-//                   :         [[INT]], 
-//   CHECK-apple-SAME:         %objc_class*, 
-// CHECK-unknown-SAME:         %swift.type*, 
-//   CHECK-apple-SAME:         %swift.opaque*, 
-//   CHECK-apple-SAME:         %swift.opaque*, 
-//   CHECK-apple-SAME:         [[INT]], 
-//         CHECK-SAME:         i32, 
-//         CHECK-SAME:         i32, 
-//         CHECK-SAME:         i32, 
-//         CHECK-SAME:         i16, 
-//         CHECK-SAME:         i16, 
-//         CHECK-SAME:         i32, 
-//         CHECK-SAME:         i32, 
-//         CHECK-SAME:         %swift.type_descriptor*, 
-//         CHECK-SAME:         i8*, 
-//         CHECK-SAME:         %swift.type*, 
-//         CHECK-SAME:         [[INT]], 
-//         CHECK-SAME:         %T4main9Argument1[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
-//         CHECK-SAME:       }>* @"$s4main9Argument1[[UNIQUE_ID_1]]CySiGMf" 
-//         CHECK-SAME:       to %swift.full_heapmetadata*
-//         CHECK-SAME:     ), 
+//         CHECK-SAME:     $s4main9Argument1[[UNIQUE_ID_1]]CySiGMf
 //         CHECK-SAME:     i32 0, 
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ), 
 //         CHECK-SAME:   [[INT]] {{(16|8)}}, 
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*, 
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -254,31 +183,24 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 //      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_TYPE]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:     ptr %1, 
+//      CHECK:     ptr undef, 
+//      CHECK:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
 // CHECK:; Function Attrs: noinline nounwind readnone
-// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[REQUEST:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[REQUEST:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK-unknown:    ret
-// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-// CHECK-SAME: @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf"
-// CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
-// CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-// CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,13 +9,13 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)*, 
-//         CHECK-SAME:   i8**, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //                   :   [[INT]], 
-//   CHECK-apple-SAME:   %objc_class*
-// CHECK-unknown-SAME:   %swift.type*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
-//   CHECK-apple-SAME:   %swift.opaque*, 
+//   CHECK-apple-SAME:   ptr
+// CHECK-unknown-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
+//   CHECK-apple-SAME:   ptr, 
 //   CHECK-apple-SAME:   [[INT]], 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
@@ -25,34 +24,22 @@
 //         CHECK-SAME:   i16, 
 //         CHECK-SAME:   i32, 
 //         CHECK-SAME:   i32, 
-//         CHECK-SAME:   %swift.type_descriptor*, 
-//         CHECK-SAME:   i8*, 
-//         CHECK-SAME:   %swift.type*, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
+//         CHECK-SAME:   ptr, 
 //         CHECK-SAME:   [[INT]], 
-//   CHECK-apple-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
+//   CHECK-apple-SAME:   ptr
 //         CHECK-SAME: }> <{ 
-//         CHECK-SAME:   void (%T4main5Value[[UNIQUE_ID_1]]C*)* 
+//         CHECK-SAME:   ptr
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CySiGMM
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache, 
-//   CHECK-apple-SAME:   %swift.opaque* null, 
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null, 
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       { 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//   CHECK-apple-SAME:         i32, 
-//                   :         i32, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         { i32, i32, [1 x { [[INT]]*, i8*, i8*, i32, i32 }] }*, 
-//   CHECK-apple-SAME:         i8*, 
-//   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 
@@ -65,11 +52,10 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}}, 
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}}, 
-//                   :   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*), 
-//         CHECK-SAME:   i8* null, 
-//         CHECK-SAME:   %swift.type* @"$sSiN", 
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
+//         CHECK-SAME:   ptr null, 
+//         CHECK-SAME:   $sSiN
 //         CHECK-SAME:   [[INT]] {{(16|8)}}, 
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (%swift.opaque*, %swift.type*)* 
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -91,40 +77,29 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CySiGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
 }
 doit()
 
-// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK:     i8* [[ERASED_TYPE]], 
-// CHECK:     i8* undef, 
-// CHECK:     i8* undef, 
-// CHECK:     %swift.type_descriptor* bitcast (
-//      :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-// CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
-// CHECK:       to %swift.type_descriptor*
-// CHECK:     )
-// CHECK:   ) #{{[0-9]+}}
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:        call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }
 
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]CySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-// CHECK-apple:    %objc_class* bitcast (
-// CHECK-unknown:    ret
-// CHECK-SAME:   @"$s4main5Value[[UNIQUE_ID_1]]CySiGMf" 
-// CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+// CHECK-SAME:    $s4main5Value[[UNIQUE_ID_1]]CySiGMf
+// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 // CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 // CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -34,15 +33,15 @@ func consume<T>(_ t: T) {
 //       __swift_instantiateConcreteTypeFromMangledName.
 
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+//      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCyAA3BoxACLLCGMD"
-//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+//      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Box(value: 13)) )

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -24,15 +23,15 @@ func consume<T>(_ t: T) {
 //       should be no call to __swift_instantiateConcreteTypeFromMangledName.
 
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+//      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySSSicGMD"
-//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+//      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: { (i: Int) -> String in fatalError() }) )

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -12,15 +11,13 @@
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -29,53 +26,23 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   i8*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr 
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-// CHECK-unknown-SAME:   %swift.type* null,
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+// CHECK-unknown-SAME:   ptr null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf" to [[INT]]
-//   CHECK-apple-SAME:     ),
+//   CHECK-apple-SAME:      _DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf"{{[^)]*}})
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
 //         CHECK-SAME:   i32 26,
@@ -86,73 +53,15 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}},
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//                   :     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main3Box[[UNIQUE_ID_1:[a-zA-Z0-9_]+]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main3Box[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main3Box[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main3Box[[UNIQUE_ID_1]]LLCySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -183,28 +92,22 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Box(value: 13)) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_TYPE]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -212,46 +115,10 @@ doit()
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 //         CHECK: entry:
 // CHECK-unknown: ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :    %objc_class* bitcast (
-//              :      %swift.type* getelementptr inbounds (
-//              :        %swift.full_heapmetadata,
-//              :        %swift.full_heapmetadata* bitcast (
-//              :          <{
-//              :            void (
-//              :              %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC*
-//              :            )*,
-//              :            i8**,
-//              :            [[INT]],
-//              :            %objc_class*,
-//              :            %swift.opaque*,
-//              :            %swift.opaque*,
-//              :            [[INT]],
-//              :            i32,
-//              :            i32,
-//              :            i32,
-//              :            i16,
-//              :            i16,
-//              :            i32,
-//              :            i32,
-//              :            %swift.type_descriptor*,
-//              :            i8*,
-//              :            %swift.type*,
-//              :            [[INT]],
-//              :            %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC* (
-//              :              %swift.opaque*,
-//              :              %swift.type*
-//              :            )*
-//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf" 
-//              :           to %swift.full_heapmetadata*
-//              :         ),
-//              :         i32 0,
-//              :         i32 2
-//              :       ) to %objc_class*
-//              :     )
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf
 //              :   )
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -12,15 +11,13 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -29,51 +26,23 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   i8*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr 
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf" to [[INT]]
+//   CHECK-apply-SAME:       _DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -85,73 +54,15 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}},
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//                   :     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_heapmetadata,
-//         CHECK-SAME:     %swift.full_heapmetadata* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         void (
-//         CHECK-SAME:           %T4main3Box[[UNIQUE_ID_1:[a-zA-Z0-9_]+]]LLC*
-//         CHECK-SAME:         )*,
-//         CHECK-SAME:         i8**,
-//                   :         [[INT]],
-//   CHECK-apple-SAME:         %objc_class*,
-// CHECK-unknown-SAME:         %swift.type*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         %swift.opaque*,
-//   CHECK-apple-SAME:         [[INT]],
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i16,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         i32,
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         i8*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %T4main3Box[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:           %swift.opaque*,
-//         CHECK-SAME:           %swift.type*
-//         CHECK-SAME:         )*
-//         CHECK-SAME:       }>* @"$s4main3Box[[UNIQUE_ID_1]]LLCyAA5InnerACLLCySiGGMf" to %swift.full_heapmetadata*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main3Box[[UNIQUE_ID_1]]LLCyAA5InnerACLLCySiGGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 3
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -190,28 +101,23 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}},
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}},
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Box(value: Inner(value: 13))) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 //      CHECK:     [[INT]] [[METADATA_REQUEST]],
-//      CHECK:     i8* [[ERASED_TYPE]],
-//      CHECK:     i8* undef,
-//      CHECK:     i8* undef,
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>*
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:     ptr %1,
+//      CHECK:     ptr undef,
+//      CHECK:     ptr undef,
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
@@ -219,46 +125,15 @@ doit()
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 //         CHECK: entry:
 // CHECK-unknown: ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :    %objc_class* bitcast (
-//              :      %swift.type* getelementptr inbounds (
-//              :        %swift.full_heapmetadata,
-//              :        %swift.full_heapmetadata* bitcast (
-//              :          <{
-//              :            void (
-//              :              %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC*
-//              :            )*,
-//              :            i8**,
-//              :            [[INT]],
-//              :            %objc_class*,
-//              :            %swift.opaque*,
-//              :            %swift.opaque*,
-//              :            [[INT]],
-//              :            i32,
-//              :            i32,
-//              :            i32,
-//              :            i16,
-//              :            i16,
-//              :            i32,
-//              :            i32,
-//              :            %swift.type_descriptor*,
-//              :            i8*,
-//              :            %swift.type*,
-//              :            [[INT]],
-//              :            %T4main5Value33_9100AE3EFBE408E03C856CED54B18B61LLC* (
-//              :              %swift.opaque*,
-//              :              %swift.type*
-//              :            )*
-//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf"
-//              :           to %swift.full_heapmetadata*
-//              :         ),
-//              :         i32 0,
-//              :         i32 2
-//              :       ) to %objc_class*
-//              :     )
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//              :    ptr getelementptr inbounds (
+//              :      %swift.full_heapmetadata,
+//    CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf
+//              :       i32 0,
+//              :       i32 2
+//              :     ) to ptr
 //              :   )
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,15 +9,13 @@
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -27,52 +24,23 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   i8*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-// CHECK-unknown-SAME:   %swift.type* null,
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+// CHECK-unknown-SAME:   ptr null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       {
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//                   :         i32,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             1 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf"{{[^,]*}} to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -84,7 +52,7 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}},
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
+//                   :   ptr bitcast (
 //                   :     <{
 //                   :       i32,
 //                   :       i32,
@@ -110,28 +78,16 @@
 //                   :       i32,
 //                   :       i32,
 //                   :       %swift.method_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
+//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to ptr
 //                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_type,
-//         CHECK-SAME:     %swift.full_type* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         i8**,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         i64
-//         CHECK-SAME:       }>* @"$s4main6Either[[UNIQUE_ID_1]]OySiGMf" to %swift.full_type*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main6Either[[UNIQUE_ID_1]]OySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 2
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -161,84 +117,39 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA6EitherACLLOySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Either.left(13)) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 //      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_TYPE]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+//      CHECK:     ptr %1, 
+//      CHECK:     ptr undef, 
+//      CHECK:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
 //         CHECK: ; Function Attrs: noinline nounwind readnone
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
 // CHECK-unknown: ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :     %objc_class* bitcast (
-//              :       %swift.type* getelementptr inbounds (
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//              :     ptr bitcast (
+//              :       ptr getelementptr inbounds (
 //              :         %swift.full_heapmetadata,
-//              :         %swift.full_heapmetadata* bitcast (
-//              :           <{
-//              :             void (
-//              :               %T4main5Value[
-//              :                 [
-//              :                   UNIQUE_ID_1
-//              :                 ]
-//              :               ]C*
-//              :             )*,
-//              :             i8**,
-//              :             [[INT]],
-//              :             %objc_class*,
-//              :             %swift.opaque*,
-//              :             %swift.opaque*,
-//              :             [[INT]],
-//              :             i32,
-//              :             i32,
-//              :             i32,
-//              :             i16,
-//              :             i16,
-//              :             i32,
-//              :             i32,
-//              :             %swift.type_descriptor*,
-//              :             i8*,
-//              :             %swift.type*,
-//              :             [[INT]],
-//              :             %T4main5Value[
-//              :               [
-//              :                 UNIQUE_ID_1
-//              :               ]
-//              :             ]C* (
-//              :               %swift.opaque*,
-//              :               %swift.type*
-//              :             )*
-//              :           }>* 
-//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf" 
-//              :           to %swift.full_heapmetadata*
-//              :         ),
+//    CHECK-SAME:         $s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf
 //              :         i32 0,
 //              :         i32 2
-//              :       ) to %objc_class*
+//              :       ) to ptr
 //              :     )
 //              :   )
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,15 +9,12 @@
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//         CHECK-SAME:   )*,
-//         CHECK-SAME:   i8**,
+//         CHECK-SAME:   ptr,
 //                   :   [[INT]],
-//   CHECK-apple-SAME:   %objc_class*,
-// CHECK-unknown-SAME:   %swift.type*,
-//   CHECK-apple-SAME:   %swift.opaque*,
-//   CHECK-apple-SAME:   %swift.opaque*,
+//   CHECK-apple-SAME:   ptr,
+// CHECK-unknown-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
+//   CHECK-apple-SAME:   ptr,
 //   CHECK-apple-SAME:   [[INT]],
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
@@ -27,52 +23,23 @@
 //         CHECK-SAME:   i16,
 //         CHECK-SAME:   i32,
 //         CHECK-SAME:   i32,
-//         CHECK-SAME:   %swift.type_descriptor*,
-//         CHECK-SAME:   i8*,
-//         CHECK-SAME:   %swift.type*,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
+//         CHECK-SAME:   ptr,
 //         CHECK-SAME:   [[INT]],
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
-//         CHECK-SAME:   )*
+//         CHECK-SAME:   ptr
 //         CHECK-SAME: }> <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:     %T4main5Value[[UNIQUE_ID_1]]C*
-//                   :   $s4main5Value[[UNIQUE_ID_1]]CfD
+//                   :     $s4main5Value[[UNIQUE_ID_1]]CfD
 //         CHECK-SAME:   $sBoWV
 //   CHECK-apple-SAME:   $s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMM
 // CHECK-unknown-SAME:   [[INT]] 0,
 //   CHECK-apple-SAME:   OBJC_CLASS_$__TtCs12_SwiftObject
-// CHECK-unknown-SAME:   %swift.type* null,
-//   CHECK-apple-SAME:   %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:   %swift.opaque* null,
+// CHECK-unknown-SAME:   ptr null,
+//   CHECK-apple-SAME:   _objc_empty_cache
+//   CHECK-apple-SAME:   ptr null,
 //   CHECK-apple-SAME:   [[INT]] add (
 //   CHECK-apple-SAME:     [[INT]] ptrtoint (
-//   CHECK-apple-SAME:       {
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//   CHECK-apple-SAME:         i32,
-//                   :         i32,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         {
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           i32,
-//   CHECK-apple-SAME:           [
-//   CHECK-apple-SAME:             1 x {
-//   CHECK-apple-SAME:               [[INT]]*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i8*,
-//   CHECK-apple-SAME:               i32,
-//   CHECK-apple-SAME:               i32
-//   CHECK-apple-SAME:             }
-//   CHECK-apple-SAME:           ]
-//   CHECK-apple-SAME:         }*,
-//   CHECK-apple-SAME:         i8*,
-//   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf" to [[INT]]
+//   CHECK-apple-SAME:       ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf"{{[^,]*}} to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),
@@ -84,57 +51,15 @@
 //   CHECK-apple-SAME:   i32 {{(128|76)}},
 // CHECK-unknown-SAME:   i32 104,
 //         CHECK-SAME:   i32 {{(24|12)}},
-//                   :   %swift.type_descriptor* bitcast (
-//                   :     <{
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i32,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i16,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i8,
-//                   :       i32,
-//                   :       i32,
-//                   :       %swift.method_descriptor
-//                   :     }>* @"$s4main5Value[[UNIQUE_ID_1]]CMn" to %swift.type_descriptor*
-//                   :   ),
-//         CHECK-SAME:   i8* null,
-//         CHECK-SAME:   %swift.type* getelementptr inbounds (
+//                   :   $s4main5Value[[UNIQUE_ID_1]]CMn
+//         CHECK-SAME:   ptr null,
+//         CHECK-SAME:   ptr getelementptr inbounds (
 //         CHECK-SAME:     %swift.full_type,
-//         CHECK-SAME:     %swift.full_type* bitcast (
-//         CHECK-SAME:       <{
-//         CHECK-SAME:         i8**,
-//         CHECK-SAME:         [[INT]],
-//         CHECK-SAME:         %swift.type_descriptor*,
-//         CHECK-SAME:         %swift.type*,
-//         CHECK-SAME:         i32,
-//                   :         [
-//                   :           4 x i8
-//                   :         ],
-//         CHECK-SAME:         i64
-//         CHECK-SAME:       }>* @"$s4main4Left[[UNIQUE_ID_1]]VySiGMf" to %swift.full_type*
-//         CHECK-SAME:     ),
+//         CHECK-SAME:     $s4main4Left[[UNIQUE_ID_1]]VySiGMf
 //         CHECK-SAME:     i32 0,
 //         CHECK-SAME:     i32 2
 //         CHECK-SAME:   ),
 //         CHECK-SAME:   [[INT]] {{(16|8)}},
-//         CHECK-SAME:   %T4main5Value[[UNIQUE_ID_1]]C* (
-//         CHECK-SAME:     %swift.opaque*,
-//         CHECK-SAME:     %swift.type*
 //         CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]C5firstADyxGx_tcfC
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
@@ -163,84 +88,32 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA4LeftACLLVySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: Left(left: 13)) )
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     i8* [[ERASED_TYPE]], 
-//      CHECK:     i8* undef, 
-//      CHECK:     i8* undef, 
-//      CHECK:     %swift.type_descriptor* bitcast (
-//           :       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, %swift.method_descriptor }>* 
-//      CHECK:       $s4main5Value[[UNIQUE_ID_1]]CMn
-//      CHECK:       to %swift.type_descriptor*
-//      CHECK:     )
-//      CHECK:   ) #{{[0-9]+}}
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
 //         CHECK: ; Function Attrs: noinline nounwind readnone
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
 // CHECK-unknown: ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//              :     %objc_class* bitcast (
-//              :       %swift.type* getelementptr inbounds (
-//              :         %swift.full_heapmetadata,
-//              :         %swift.full_heapmetadata* bitcast (
-//              :           <{
-//              :             void (
-//              :               %T4main5Value[
-//              :                 [
-//              :                   UNIQUE_ID_1
-//              :                 ]
-//              :               ]C*
-//              :             )*,
-//              :             i8**,
-//              :             [[INT]],
-//              :             %objc_class*,
-//              :             %swift.opaque*,
-//              :             %swift.opaque*,
-//              :             [[INT]],
-//              :             i32,
-//              :             i32,
-//              :             i32,
-//              :             i16,
-//              :             i16,
-//              :             i32,
-//              :             i32,
-//              :             %swift.type_descriptor*,
-//              :             i8*,
-//              :             %swift.type*,
-//              :             [[INT]],
-//              :             %T4main5Value[
-//              :               [
-//              :                 UNIQUE_ID_1
-//              :               ]
-//              :             ]C* (
-//              :               %swift.opaque*,
-//              :               %swift.type*
-//              :             )*
-//              :           }>* 
-//    CHECK-SAME:           @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf" 
-//              :           to %swift.full_heapmetadata*
-//              :         ),
-//              :         i32 0,
-//              :         i32 2
-//              :       ) to %objc_class*
-//              :     )
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf
 //              :   )
-//   CHECK-apple:   [[INITIALIZED_METADATA:%[0-9]+]] = bitcast %objc_class* [[INITIALIZED_CLASS]] to %swift.type*
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[INITIALIZED_METADATA]], 0
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -24,15 +23,15 @@ func consume<T>(_ t: T) {
 //       should be no call to __swift_instantiateConcreteTypeFromMangledName.
 
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-//      CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+//      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySi_SStGMD"
-//      CHECK:   {{%[0-9]+}} = call swiftcc %T4main5Value[[UNIQUE_ID_1]]LLC* @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* swiftself [[METADATA]]
+//      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[METADATA]])
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Value(first: (13, "13")) )

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestor-1du-1st_ancestor_generic-fileprivate-2nd_ancestor_nongeneric.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestor-1du-1st_ancestor_generic-fileprivate-2nd_ancestor_nongeneric.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s > %t/out.ir
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s > %t/out.ir
 // RUN: %FileCheck --input-file=%t/out.ir %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
@@ -13,14 +12,12 @@
 //   CHECK-apple-SAME: global
 // CHECK-unknown-SAME: constant
 //         CHECK-SAME: <{
-//         CHECK-SAME:   void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  i8**,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //                   :  [[INT]],
-//         CHECK-SAME:  %swift.type*,
-//   CHECK-apple-SAME:  %swift.opaque*,
-//   CHECK-apple-SAME:  %swift.opaque*,
+//         CHECK-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
+//   CHECK-apple-SAME:  ptr,
 //   CHECK-apple-SAME:  [[INT]],
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
@@ -29,99 +26,26 @@
 //         CHECK-SAME:  i16,
 //         CHECK-SAME:  i32,
 //         CHECK-SAME:  i32,
-//         CHECK-SAME:  %swift.type_descriptor*,
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
-//         CHECK-SAME:  )*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]],
-//         CHECK-SAME:  %T4main9Ancestor2[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*,
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
-//         CHECK-SAME:  )*
-//         CHECK-SAME:  %swift.type*,
+//         CHECK-SAME:  ptr,
+//         CHECK-SAME:  ptr,
 //         CHECK-SAME:  [[INT]]
 //         CHECK-SAME:}> <{
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfD
 //         CHECK-SAME:  $sBoWV
 //   CHECK-apple-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCySiGMM
 // CHECK-unknown-SAME:  [[INT]] 0,
-//                   :  %swift.type* getelementptr inbounds (
-//                   :    %swift.full_heapmetadata,
-//                   :    %swift.full_heapmetadata* bitcast (
-//                   :      <{
-//                   :        void (
-//                   :          %T4main9Ancestor2[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        i8**,
-//                   :        [[INT]],
-//                   :        %swift.type*,
-//                   :        %swift.opaque*,
-//                   :        %swift.opaque*,
-//                   :        [[INT]],
-//                   :        i32,
-//                   :        i32,
-//                   :        i32,
-//                   :        i16,
-//                   :        i16,
-//                   :        i32,
-//                   :        i32,
-//                   :        %swift.type_descriptor*,
-//                   :        void (
-//                   :          %T4main9Ancestor2[[UNIQUE_ID_1]]LLC*
-//                   :        )*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor2[[UNIQUE_ID_1]]LLC* (
-//                   :          [[INT]],
-//                   :          %swift.type*
-//                   :        )*,
-//                   :        %swift.type*,
-//                   :        [[INT]],
-//                   :        %T4main9Ancestor2[[UNIQUE_ID_1]]LLC* (
-//                   :          %swift.opaque*,
-//                   :          %swift.type*
-//                   :        )*
-//                   :      }>* @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//                   :    ),
-//                   :    i32 0,
-//                   :    i32 2
-//                   :  ),
-//   CHECK-apple-SAME:  %swift.opaque* @_objc_empty_cache,
-//   CHECK-apple-SAME:  %swift.opaque* null,
+//                   :  $s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMf
+//   CHECK-apple-SAME:  _objc_empty_cache
+//   CHECK-apple-SAME:  ptr null,
 //   CHECK-apple-SAME:  [[INT]] add (
 //   CHECK-apple-SAME:    [[INT]] ptrtoint (
-//   CHECK-apple-SAME:      {
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//   CHECK-apple-SAME:        i32,
-//                   :        i32,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*,
-//                   :        i8*,
-//   CHECK-apple-SAME:        {
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          i32,
-//   CHECK-apple-SAME:          [
-//   CHECK-apple-SAME:            1 x {
-//   CHECK-apple-SAME:              [[INT]]*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i8*,
-//   CHECK-apple-SAME:              i32,
-//   CHECK-apple-SAME:              i32
-//   CHECK-apple-SAME:            }
-//   CHECK-apple-SAME:          ]
-//   CHECK-apple-SAME:        }*,
-//   CHECK-apple-SAME:        i8*,
-//   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
+//   CHECK-apple-SAME:      ptr {{[^@]*}}@"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),
@@ -133,48 +57,14 @@
 //   CHECK-apple-SAME:  i32 {{(160|92)}},
 // CHECK-unknown-SAME:  i32 136,
 //         CHECK-SAME:  i32 {{(24|12)}},
-//                   :  %swift.type_descriptor* bitcast (
-//                   :    <{
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i32,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i16,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i8,
-//                   :      i32,
-//                   :      %swift.method_override_descriptor
-//         CHECK-SAME:    $s4main5Value[[UNIQUE_ID_2:[A-Za-z_0-9]+]]LLCMn
-//         CHECK-SAME:  ),
-//         CHECK-SAME:  void (
-//         CHECK-SAME:    %T4main5Value[[UNIQUE_ID_1]]LLC*
+//         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_2:[A-Za-z_0-9]+]]LLCMn
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLCfE
 //         CHECK-SAME:  [[INT]] {{16|8}},
-//         CHECK-SAME:  %T4main9Ancestor2[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    [[INT]],
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main9Ancestor2[[UNIQUE_ID_1]]LLCyADyxGSicfC
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{24|12}}
-//         CHECK-SAME:  %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//         CHECK-SAME:    %swift.opaque*,
-//         CHECK-SAME:    %swift.type*
 //         CHECK-SAME:  $s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC
-//         CHECK-SAME:  %swift.type* @"$sSiN",
+//         CHECK-SAME:  $sSiN
 //         CHECK-SAME:  [[INT]] {{32|16}}
 //         CHECK-SAME:}>,
 //         CHECK-SAME:align [[ALIGNMENT]]
@@ -222,57 +112,19 @@ doit()
 
 //              CHECK: ; Function Attrs: noinline nounwind readnone
 //              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK-NEXT: entry:
 //              CHECK:   [[SUPERCLASS_METADATA:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 //      CHECK-unknown:   ret
-//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call %objc_class* @objc_opt_self(
-//                   :     %objc_class* bitcast (
-//                   :       %swift.type* getelementptr inbounds (
+//        CHECK-apple:   [[THIS_CLASS_METADATA:%[0-9]+]] = call ptr @objc_opt_self(
+//                   :     ptr bitcast (
+//                   :       ptr getelementptr inbounds (
 //                   :         %swift.full_heapmetadata,
-//                   :         %swift.full_heapmetadata* bitcast (
-//                   :           <{
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i8**,
-//                   :             i64,
-//                   :             %swift.type*,
-//                   :             %swift.opaque*,
-//                   :             %swift.opaque*,
-//                   :             i64,
-//                   :             i32,
-//                   :             i32,
-//                   :             i32,
-//                   :             i16,
-//                   :             i16,
-//                   :             i32,
-//                   :             i32,
-//                   :             %swift.type_descriptor*,
-//                   :             void (
-//                   :               %T4main5Value[[UNIQUE_ID_1]]LLC*
-//                   :             )*,
-//                   :             i64,
-//                   :             %T4main9Ancestor2[[UNIQUE_ID_1]]LLC* (
-//                   :               i64,
-//                   :               %swift.type*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             i64,
-//                   :             %T4main5Value[[UNIQUE_ID_1]]LLC* (
-//                   :               %swift.opaque*,
-//                   :               %swift.type*
-//                   :             )*,
-//                   :             %swift.type*,
-//                   :             i64
-//         CHECK-SAME:           }>* @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to %swift.full_heapmetadata*
-//                   :         ),
+//         CHECK-SAME:         $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
 //                   :         i32 0,
 //                   :         i32 2
-//                   :       ) to %objc_class*
+//                   :       ) to ptr
 //                   :     )
 //                   :   )
-//        CHECK-apple:   [[THIS_TYPE_METADATA:%[0-9]+]] = bitcast %objc_class* [[THIS_CLASS_METADATA]] to %swift.type*
-//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, %swift.type* [[THIS_TYPE_METADATA]], 0
+//        CHECK-apple:   [[RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[THIS_CLASS_METADATA]], 0
 //        CHECK-apple:   [[COMPLETE_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[RESPONSE]], [[INT]] 0, 1
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -parse-stdlib -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -parse-stdlib -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -parse-stdlib -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -24,9 +23,9 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK: entry:
-// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9NamespaceCA2A4ZangCRszlE19ExtensionNonGenericCyAE_GMa"([[INT]] 0) #{{[0-9]+}}
+// CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9NamespaceCA2A4ZangCRszlE19ExtensionNonGenericCyAE_GMa"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %5, %swift.type* [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%.*}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Namespace<Zang>.ExtensionNonGeneric() )

--- a/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -20,10 +19,10 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.type* (
-//           :           %swift.type_descriptor*, 
-//           :           i8**, 
-//           :           i8*
+//           :         ptr (
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main6EitherOMi" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -35,9 +34,9 @@
 //           :     i64 sub (
 //           :       i64 ptrtoint (
 //           :         %swift.metadata_response (
-//           :           %swift.type*, 
-//           :           i8*, 
-//           :           i8**
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main6EitherOMr" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -54,7 +53,7 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.enum_vwtable* @"$s4main6EitherOWV" to i64
+//           :         ptr @"$s4main6EitherOWV" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
 //           :         i32* getelementptr inbounds (
@@ -69,14 +68,12 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         ptr [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main6EitherOMP", 
+// CHECK-SAME:           $s4main6EitherOMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
@@ -45,7 +45,7 @@
 //           :       i64 ptrtoint (
 //           :         ptr getelementptr inbounds (
 //           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-//           :           ptr @"$s4main6EitherOMP", 
+//           :           $s4main6EitherOMP
 //           :           i32 0, 
 //           :           i32 3
 //           :         ) to i64
@@ -60,7 +60,7 @@
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           ptr @"$s4main6EitherOMP", 
+// CHECK-SAME:           $s4main6EitherOMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
@@ -46,7 +46,7 @@
 //           :       i64 ptrtoint (
 //           :         ptr getelementptr inbounds (
 //           :           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-//           :           ptr @"$s4main6EitherOMP", 
+//           :           $s4main6EitherOMP
 //           :           i32 0, 
 //           :           i32 3
 //           :         ) to i64
@@ -61,7 +61,7 @@
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           ptr @"$s4main6EitherOMP", 
+// CHECK-SAME:           $s4main6EitherOMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,16 +6,16 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]OySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5Value[[UNIQUE_ID_1]]OySiGWV", i32 0, i32 0),
+//                ptr {{[^@]*}}@"$s4main5Value[[UNIQUE_ID_1]]OySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.*}}$s4main5Value[[UNIQUE_ID_1]]OMn{{.*}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main5Value[[UNIQUE_ID_1]]OMn
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -32,19 +31,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5Value[[UNIQUE_ID_1]]OySiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]OySiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -56,17 +46,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]OMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]OMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5Value[[UNIQUE_ID_1]]OMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]OMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,20 +6,20 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceC5ValueOySi_GMf" = linkonce_odr hidden constant <{
-// CHECk-SAME:    i8**,
+// CHECk-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME: }> <{
-//                i8** getelementptr inbounds (
+//                ptr getelementptr inbounds (
 //                  %swift.enum_vwtable, 
-//                  %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySi_GWV", 
+//                  ptr @"$s4main9NamespaceC5ValueOySi_GWV", 
 //                  i32 0, 
 //                  i32 0
 //                ),
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.*}}$s4main9NamespaceC5ValueOMn{{.*}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main9NamespaceC5ValueOMn
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -39,19 +38,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySi_GMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceC5ValueOySi_GMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -63,17 +53,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main9NamespaceC5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceC5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -23,17 +22,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,20 +8,18 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueOySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    $s4main5ValueOySiGWV
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    $s4main5ValueOMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -40,20 +37,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5ValueOySiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -65,18 +52,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* [[ERASED_TABLE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 // CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public-empty.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -32,20 +31,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5ValueOyS2i10TestModule1PAAyHCg_GMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -57,18 +46,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* [[ERASED_TABLE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 // CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public-empty.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -31,10 +30,11 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMD") #{{[0-9]+}}
+// CHECK:      [[DEMANGLED_TYPE:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:     $s4main5ValueOyS2i10TestModule1PAAyHCg_GMD
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr [[DEMANGLED_TYPE]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
@@ -43,18 +43,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* [[ERASED_TABLE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   )
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,20 +8,18 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueOySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    $s4main5ValueOySiGWV
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    $s4main5ValueOMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -40,20 +37,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5ValueOySiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -65,18 +52,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* [[ERASED_TABLE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   )
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -27,18 +26,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_CONFORMANCE:%[0-9]+]] = bitcast i8** %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* [[ERASED_CONFORMANCE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -8,39 +7,16 @@
 
 // CHECK: @"$s4main5OuterOyAA5InnerVySiGGWV" = linkonce_odr hidden constant %swift.enum_vwtable
 // CHECK: @"$s4main5OuterOyAA5InnerVySiGGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> <{ 
-// CHECK-SAME:   i8** getelementptr inbounds (
-// CHECK-SAME:     %swift.enum_vwtable, 
-// CHECK-SAME:     %swift.enum_vwtable* @"$s4main5OuterOyAA5InnerVySiGGWV", 
-// CHECK-SAME:     i32 0, 
-// CHECK-SAME:     i32 0
-// CHECK-SAME:   ), 
+// CHECK-SAME:   $s4main5OuterOyAA5InnerVySiGGWV
 // CHECK-SAME:   [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5OuterOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
-// CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         i32, 
-// CHECK-SAME:         {{(\[4 x i8\],)?}}
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5InnerVySiGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
-// CHECK-SAME:     i32 0, 
-// CHECK-SAME:     i32 2
-// CHECK-SAME:   ), 
+// CHECK-SAME:   $s4main5OuterOMn
+// CHECK-SAME:   $s4main5InnerVySiGMf
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 enum Outer<First> {
@@ -59,19 +35,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5OuterOyAA5InnerVySiGGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5OuterOyAA5InnerVySiGGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -83,17 +50,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5OuterOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5OuterOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,35 +6,33 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwCP{{[^\)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwxx{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwcp{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwca{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwtk{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwta{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwet{{[^)]+}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwst{{[^)]+}} to i8*), 
+// CHECK-SAME:   $s4main5ValueOwCP
+// CHECK-SAME:   $s4main5ValueOwxx
+// CHECK-SAME:   $s4main5ValueOwcp
+// CHECK-SAME:   $s4main5ValueOwca
+// CHECK-SAME:   $s4main5ValueOwtk
+// CHECK-SAME:   $s4main5ValueOwta
+// CHECK-SAME:   $s4main5ValueOwet
+// CHECK-SAME:   $s4main5ValueOwst
 // CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
 // CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
 // CHECK-SAME:   i32 {{[0-9]+}}, 
 // CHECK-SAME:   i32 0, 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwug{{[^)]+}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwup{{[^)]+}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwui{{[^)]+}} to i8*) 
+// CHECK-SAME:   $s4main5ValueOwug
+// CHECK-SAME:   $s4main5ValueOwup
+// CHECK-SAME:   $s4main5ValueOwui
 // CHECK-SAME: }, align [[ALIGNMENT]]
 // CHECK: @"$s4main5ValueOySiGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> <{ 
-// CHECK-SAME: i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), 
-// CHECK-SAME: [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   $s4main5ValueOySiGWV
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 enum Value<First> {
@@ -50,8 +47,8 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 2)
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   $s4main5ValueOySiGMf
 // CHECK-SAME: )
 // CHECK: }
 func doit() {
@@ -60,17 +57,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:   [[INT]] %0, 
-// CHECK-SAME:   i8* %2, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   )
-// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME: )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,20 +6,18 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceC5ValueOySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySS_SiGWV", i32 0, i32 0),
+//                ptr {{[^@]*}}@"$s4main9NamespaceC5ValueOySS_SiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceC5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main9NamespaceC5ValueOMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -38,20 +35,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceC5ValueOySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -63,18 +50,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main9NamespaceC5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceC5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,20 +6,18 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceO5ValueOySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceO5ValueOySS_SiGWV", i32 0, i32 0)
+//                ptr {{[^@]*}}@"$s4main9NamespaceO5ValueOySS_SiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceO5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main9NamespaceO5ValueOMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -38,20 +35,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueOySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceO5ValueOySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -63,18 +50,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main9NamespaceO5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceO5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,20 +6,18 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceV5ValueOySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceV5ValueOySS_SiGWV", i32 0, i32 0),
+//                ptr {{[^@]*}}@"$s4main9NamespaceV5ValueOySS_SiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 513,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceV5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main9NamespaceV5ValueOMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -38,20 +35,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueOySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceV5ValueOySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -63,18 +50,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main9NamespaceV5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceV5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,36 +6,34 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueOyS2iGWV" = linkonce_odr hidden constant %swift.enum_vwtable {
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwCP{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwxx{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwcp{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwca{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwtk{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwta{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_getMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_storeMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
+// CHECK-SAME:   $s4main5ValueOwCP
+// CHECK-SAME:   $s4main5ValueOwxx
+// CHECK-SAME:   $s4main5ValueOwcp
+// CHECK-SAME:   $s4main5ValueOwca
+// CHECK-SAME:   $s4main5ValueOwtk
+// CHECK-SAME:   $s4main5ValueOwta
+// CHECK-SAME:   swift_getMultiPayloadEnumTagSinglePayload
+// CHECK-SAME:   swift_storeMultiPayloadEnumTagSinglePayload
 // CHECK-SAME:   [[INT]] {{[0-9]+}},
 // CHECK-SAME:   [[INT]] {{[0-9]+}},
 // CHECK-SAME:   i32 {{[0-9]+}},
 // CHECK-SAME:   i32 {{[0-9]+}},
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwug{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwup{{[^)]+}} to i8*),
-// CHECK-SAME    i8* bitcast ({{[^@]+}}@"$s4main5ValueOwui{{[^)]+}} to i8*)
+// CHECK-SAME:   $s4main5ValueOwug
+// CHECK-SAME:   $s4main5ValueOwup
+// CHECK-SAME    ptr {{[^@]*}}@"$s4main5ValueOwui{{[^}]+}}
 // CHECK-SAME: }, align [[ALIGNMENT]]
 // CHECK: @"$s4main5ValueOyS2iGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i64
 // CHECK-SAME:   }> <{
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS2iGWV", i32 0, i32 0),
+// CHECK-SAME:   $s4main5ValueOyS2iGWV
 // CHECK-SAME:   [[INT]] 513,
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ),
-// CHECK-SAME:   %swift.type* @"$sSiN",
-// CHECK-SAME:   %swift.type* @"$sSiN",
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
 // CHECK-SAME:   [[INT]] {{16|8}},
 // CHECK-SAME:   i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -53,20 +50,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5ValueOyS2iGMf" 
-// CHECK-SAME:       to %swift.full_type*), 
+// CHECK-SAME:     $s4main5ValueOyS2iGMf{{[^,]}}
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -78,18 +65,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn{{[^,]}}
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,37 +6,35 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueOyS3iGWV" = linkonce_odr hidden constant %swift.enum_vwtable {
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwCP{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwxx{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwcp{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwca{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwtk{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwta{{[^)]+}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_getMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_storeMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
+// CHECK-SAME:   $s4main5ValueOwCP
+// CHECK-SAME:   $s4main5ValueOwxx
+// CHECK-SAME:   $s4main5ValueOwcp
+// CHECK-SAME:   $s4main5ValueOwca
+// CHECK-SAME:   $s4main5ValueOwtk
+// CHECK-SAME:   $s4main5ValueOwta
+// CHECK-SAME:   swift_getMultiPayloadEnumTagSinglePayload
+// CHECK-SAME:   swift_storeMultiPayloadEnumTagSinglePayload
 // CHECK-SAME:   [[INT]] {{[0-9]+}}, 
 // CHECK-SAME:   [[INT]] {{[0-9]+}}, 
 // CHECK-SAME:   i32 {{[0-9]+}}, 
 // CHECK-SAME:   i32 {{[0-9]+}}, 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwug{{[^)]+}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwup{{[^)]+}} to i8*),
-// CHECK-SAME    i8* bitcast ({{[^@]+}}@"$s4main5ValueOwui{{[^)]+}} to i8*),
+// CHECK-SAME:   $s4main5ValueOwug
+// CHECK-SAME:   $s4main5ValueOwup
+// CHECK-SAME:   $s4main5ValueOwui
 // CHECK-SAME: }, align [[ALIGNMENT]]
 // CHECK: @"$s4main5ValueOyS3iGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME:   }> <{ 
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS3iGWV", i32 0, i32 0), 
+// CHECK-SAME:   $s4main5ValueOyS3iGWV
 // CHECK-SAME:   [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
 // CHECK-SAME:   [[INT]] {{24|12}}, 
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -55,22 +52,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5ValueOyS3iGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
+// CHECK-SAME:     $s4main5ValueOyS3iGMf
 // CHECK-SAME:     i32 0, 
 // CHECK-SAME:     i32 2
 // CHECK-SAME:   )
@@ -82,19 +67,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2, %swift.type* %3) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1, ptr %2, ptr %3) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   [[ERASED_TYPE_3:%[0-9]+]] = bitcast %swift.type* %3 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_3]], 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr %3, 
+// CHECK-SAME:     $s4main5ValueOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,38 +6,36 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueOyS4iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwCP{{[^)]*}} to i8*), 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwxx{{[^)]*}} to i8*) 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwcp{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwca{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwtk{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwta{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_getMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_storeMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
+// CHECK-SAME:   $s4main5ValueOwCP
+// CHECK-SAME:   $s4main5ValueOwxx
+// CHECK-SAME:   $s4main5ValueOwcp
+// CHECK-SAME:   $s4main5ValueOwca
+// CHECK-SAME:   $s4main5ValueOwtk
+// CHECK-SAME:   $s4main5ValueOwta
+// CHECK-SAME:   swift_getMultiPayloadEnumTagSinglePayload
+// CHECK-SAME:   swift_storeMultiPayloadEnumTagSinglePayload
 // CHECK-SAME:   [[INT]] {{[0-9]+}}, 
 // CHECK-SAME:   [[INT]] {{[0-9]+}}, 
 // CHECK-SAME:   i32 {{[0-9]+}}, 
 // CHECK-SAME:   i32 {{[0-9]+}}, 
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwug{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwup{{[^)]*}} to i8*)
-// CHECK-SAME    i8* bitcast ({{[^@]+}}@"$s4main5ValueOwui{{[^)]*}} to i8*)
+// CHECK-SAME:   $s4main5ValueOwug
+// CHECK-SAME:   $s4main5ValueOwup
+// CHECK-SAME    ptr {{[^@]*}}@"$s4main5ValueOwui{{[^,]*}}
 // CHECK-SAME: }, align [[ALIGNMENT]]
 // CHECK: @"$s4main5ValueOyS4iGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME:   }> <{ 
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS4iGWV", i32 0, i32 0), 
+// CHECK-SAME:   $s4main5ValueOyS4iGWV
 // CHECK-SAME:   [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
 // CHECK-SAME:   [[INT]] {{32|16}},
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -57,23 +54,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5ValueOyS4iGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
+// CHECK-SAME:     $s4main5ValueOyS4iGMf
 // CHECK-SAME:     i32 0, 
 // CHECK-SAME:     i32 2
 // CHECK-SAME:   )
@@ -85,15 +69,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_BUFFER]], 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     $s4main5ValueOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,35 +6,33 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueOyS5iGWV" = linkonce_odr hidden constant %swift.enum_vwtable {
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwCP{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwxx{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwcp{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwca{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwtk{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwta{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_getMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@swift_storeMultiPayloadEnumTagSinglePayload{{[^)]*}} to i8*),
+// CHECK-SAME:   $s4main5ValueOwCP
+// CHECK-SAME:   $s4main5ValueOwxx
+// CHECK-SAME:   $s4main5ValueOwcp
+// CHECK-SAME:   $s4main5ValueOwca
+// CHECK-SAME:   $s4main5ValueOwtk
+// CHECK-SAME:   $s4main5ValueOwta
+// CHECK-SAME:   swift_getMultiPayloadEnumTagSinglePayload
+// CHECK-SAME:   swift_storeMultiPayloadEnumTagSinglePayload
 // CHECK-SAME:   [[INT]] {{[0-9]+}},
 // CHECK-SAME:   [[INT]] {{[0-9]+}},
 // CHECK-SAME:   i32 {{[0-9]+}},
 // CHECK-SAME:   i32 {{[0-9]+}},
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwug{{[^)]*}} to i8*)
-// CHECK-SAME:   i8* bitcast ({{[^@]+}}@"$s4main5ValueOwup{{[^)]*}} to i8*)
-// CHECK-SAME    i8* bitcast ({{[^@]+}}@"$s4main5ValueOwui{{[^)]*}} to i8*)
+// CHECK-SAME:   $s4main5ValueOwug
+// CHECK-SAME:   $s4main5ValueOwup
+// CHECK-SAME    ptr {{[^@]*}}@"$s4main5ValueOwui{{[^,]*}}
 // CHECK-SAME: }, align [[ALIGNMENT]]
 // CHECK: @"$s4main5ValueOyS5iGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i64
 // CHECK-SAME:   }> <{
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS5iGWV", i32 0, i32 0),
+// CHECK-SAME:   $s4main5ValueOyS5iGWV
 // CHECK-SAME:   [[INT]] 513,
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ),
-// CHECK-SAME:   %swift.type* @"$sSiN",
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
 // CHECK-SAME:   [[INT]] {{40|20}},
 // CHECK-SAME:   i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -55,24 +52,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5ValueOyS5iGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
+// CHECK-SAME:     $s4main5ValueOyS5iGMf
 // CHECK-SAME:     i32 0, 
 // CHECK-SAME:     i32 2
 // CHECK-SAME:   )
@@ -84,15 +67,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_BUFFER]], 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     $s4main5ValueOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-frozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -12,19 +11,17 @@
 import TestModule
 
 // CHECK: @"$s4main5ValueOy10TestModule7IntegerVGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> 
 // CHECK-SAME: <{ 
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOy10TestModule7IntegerVGWV", i32 0, i32 0), 
+// CHECK-SAME:   $s4main5ValueOy10TestModule7IntegerVGWV
 // CHECK-SAME:   [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* @"$s10TestModule7IntegerVN", 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $s10TestModule7IntegerVN
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -40,19 +37,10 @@ enum Value<First> {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5ValueOy10TestModule7IntegerVGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
+// CHECK-SAME:     $s4main5ValueOy10TestModule7IntegerVGMf
 // CHECK-SAME:     i32 0, 
 // CHECK-SAME:     i32 2
 // CHECK-SAME:   )
@@ -64,17 +52,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:   [[INT]] %0, 
-// CHECK-SAME:   i8* %2, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   )
-// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueOMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
@@ -23,10 +22,11 @@ enum Value<First> {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOy10TestModule7IntegerVGMD") #{{[0-9]+}}
+// CHECK:      [[DEMANGLED_TYPE:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:   $s4main5ValueOy10TestModule7IntegerVGMD
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:   %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr [[DEMANGLED_TYPE]]
 // CHECK-SAME: )
 // CHECK: }
 func doit() {
@@ -35,17 +35,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -enable-library-evolution -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -enable-library-evolution -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -enable-library-evolution -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -8,18 +7,16 @@
 
 // CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable
 // CHECK: @"$s4main5ValueOySiGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> <{ 
-// CHECK-SAME: i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), 
-// CHECK-SAME: [[INT]] 513, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   ), 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   $s4main5ValueOySiGWV
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   $s4main5ValueOMn
+// CHECK-SAME:   $sSiN
 // Payload size.
 // CHECK-SAME:   [[INT]] 8,
 // Trailing flags.
@@ -52,19 +49,10 @@ func consume<T>(_ t: T) {
 
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main5ValueOySiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -76,18 +64,13 @@ func doit() {
 doit()
 
 //      CHECK: ; Function Attrs: noinline nounwind readnone
-//      CHECK: define{{( protected)?}} swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:   [[INT]] %0, 
-// CHECK-SAME:   i8* %2, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   i8* undef, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast (
-// CHECK-SAME:     {{.*}}$s4main5ValueOMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:   )
-// CHECK-SAME: ) #{{[0-9]+}}
+//      CHECK: define{{( protected)?}} swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5ValueOMn
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 

--- a/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/enum-public-nonfrozen-1argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,15 +8,15 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03OneA0Oy4main03TheA0VGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.enum_vwtable,
-//           :     %swift.enum_vwtable* @"
+//           :     
 // CHECK-SAME:       $s8Argument03OneA0Oy4main03TheA0VGWV
 //           :     ",
 //           :     i32 0,
@@ -25,49 +24,7 @@
 //           :   ),
 // CHECK-SAME:   [[INT]] 513,
 // CHECK-SAME:   $s8Argument03OneA0OMn
-// CHECK-SAME:   %swift.type* bitcast (
-// CHECK-SAME:     [[INT]]* getelementptr inbounds (
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>,
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8*,
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>* @"$s4main11TheArgumentVMf",
-// CHECK-SAME:       i32 0,
-// CHECK-SAME:       i32 2
-// CHECK-SAME:     ) to %swift.type*
-// CHECK-SAME:   ),
+// CHECK-SAME:   $s4main11TheArgumentVMf
 // CHECK-SAME:   i64 1
 // CHECK-SAME: }>,
 // CHECK-SAME: align [[ALIGNMENT]]
@@ -87,26 +44,18 @@ struct TheArgument {
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03OneA0Oy4main03TheA0VGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03OneA0Oy4main03TheA0VGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:     %swift.type** @"$s8Argument03OneA0Oy4main03TheA0VGMJ"
+// CHECK-SAME:     $s8Argument03OneA0Oy4main03TheA0VGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend %use_no_opaque_pointers -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -29,10 +28,10 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.type* (
-//           :           %swift.type_descriptor*, 
-//           :           i8**, 
-//           :           i8*
+//           :         ptr (
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main4PairVMi" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -46,7 +45,7 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :         ptr @"$s4main4PairVWV" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
 //           :         i32* getelementptr inbounds (
@@ -61,16 +60,12 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         <{ i32
-// CHECK-SAME:         , i32
-// CHECK-SAME:         , i32
-//           :         , [4 x i8] 
-// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         ptr [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           $s4main4PairVMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -31,10 +30,10 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.type* (
-//           :           %swift.type_descriptor*, 
-//           :           i8**, 
-//           :           i8*
+//           :         ptr (
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main4PairVMi" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -48,7 +47,7 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :         ptr @"$s4main4PairVWV" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
 //           :         i32* getelementptr inbounds (
@@ -63,18 +62,12 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i32, 
-// CHECK-SAME:           i32, 
-// CHECK-SAME:           i32, 
-//           :           [4 x i8], 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         ptr [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           $s4main4PairVMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -20,10 +19,10 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.type* (
-//           :           %swift.type_descriptor*, 
-//           :           i8**, 
-//           :           i8*
+//           :         ptr (
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main4PairVMi" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -35,9 +34,9 @@
 //           :     i64 sub (
 //           :       i64 ptrtoint (
 //           :         %swift.metadata_response (
-//           :           %swift.type*, 
-//           :           i8*, 
-//           :           i8**
+//           :           ptr, 
+//           :           ptr, 
+//           :           ptr
 //           :         )* @"$s4main4PairVMr" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
@@ -54,7 +53,7 @@
 //           :   i32 trunc (
 //           :     i64 sub (
 //           :       i64 ptrtoint (
-//           :         %swift.vwtable* @"$s4main4PairVWV" to i64
+//           :         ptr @"$s4main4PairVWV" to i64
 //           :       ), 
 //           :       i64 ptrtoint (
 //           :         i32* getelementptr inbounds (
@@ -69,14 +68,12 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         ptr [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         i32* getelementptr inbounds (
+// CHECK-SAME:         ptr getelementptr inbounds (
 // CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>, 
-// CHECK-SAME:           <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s4main4PairVMP", 
+// CHECK-SAME:           $s4main4PairVMP
 // CHECK-SAME:           i32 0, 
 // CHECK-SAME:           i32 4
 // CHECK-SAME:         ) to [[INT]]

--- a/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,19 +6,19 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]VySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5Value33_BD97D79156BC586FAA2AE8FB32F3D812LLVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5Value33_BD97D79156BC586FAA2AE8FB32F3D812LLVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]VMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]VMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -34,7 +33,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5Value[[UNIQUE_ID_1]]VySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]VySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -42,9 +49,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]VMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]VMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5Value[[UNIQUE_ID_1]]VMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5Value[[UNIQUE_ID_1]]VMz") #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, ptr undef, 
+// CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]VMn
+// CHECK-SAME:   $s4main5Value[[UNIQUE_ID_1]]VMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,18 +6,19 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceC5ValueVySi_GMf" = linkonce_odr hidden constant <{
-// CHECk-SAME:    i8**,
+// CHECk-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}}, i64
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32, 
+// CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySi_GWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main9NamespaceC5ValueVySi_GWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main9NamespaceC5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main9NamespaceC5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -36,7 +36,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceC5ValueVySi_GMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main9NamespaceC5ValueVySi_GMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Namespace.Value(first: 13) )
@@ -44,9 +52,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main9NamespaceC5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main9NamespaceC5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr {{.+}}$s4main9NamespaceC5ValueVMn{{.+}}, 
+// CHECK-SAME:   $s4main9NamespaceC5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
@@ -16,7 +16,22 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture %{{[0-9]+}}, ptr getelementptr inbounds (<{ ptr, ptr, [[INT]], ptr, i32{{(, \[4 x i8\])?}}, i64 }>, ptr @"$s4main5ValueVMf", i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     <{ 
+// CHECK-SAME:       ptr, 
+// CHECK-SAME:       ptr, 
+// CHECK-SAME:       [[INT]], 
+// CHECK-SAME:       ptr, 
+// CHECK-SAME:       i32
+// CHECK-SAME:       i64 
+// CHECK-SAME:     }>, 
+// CHECK-SAME:     ptr @"$s4main5ValueVMf", 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -23,9 +22,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,21 +8,21 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -40,7 +39,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i8**, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -48,10 +55,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz")
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -target %module-target-future -emit-ir %s
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -27,10 +26,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_CONFORMANCE:%[0-9]+]] = bitcast i8** %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_CONFORMANCE]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -25,22 +24,11 @@ func consume<T>(_ t: T) {
 //       themselves generic (Outer<Inner<Int>>, here), a direct reference to
 //       the prespecialized metadata should be emitted here.
 // CHECK: call swiftcc void @"$s4main5OuterV5firstACyxGx_tcfC"(
-// CHECK-SAME:   %swift.opaque* noalias nocapture sret({{.*}}) %{{[0-9]+}},
-// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:   ptr noalias nocapture sret({{.*}}) %{{[0-9]+}},
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
-// CHECK-SAME:     %swift.full_type* bitcast (
-// CHECK-SAME:       <{ 
-// CHECK-SAME:         i8**, 
-// CHECK-SAME:         [[INT]], 
-// CHECK-SAME:         %swift.type_descriptor*, 
-// CHECK-SAME:         %swift.type*, 
-// CHECK-SAME:         i32, 
-// CHECK-SAME:         {{(\[4 x i8\],)?}} 
-// CHECK-SAME:         i64 
-// CHECK-SAME:       }>* @"$s4main5InnerVySiGMf" 
-// CHECK-SAME:       to %swift.full_type*
-// CHECK-SAME:     ), 
+// CHECK-SAME:     $s4main5InnerVySiGMf
 // CHECK-SAME:     i32 0, 
 // CHECK-SAME:     i32 2
 // CHECK-SAME:   )
@@ -52,33 +40,26 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.+}}$s4main5OuterVMn{{.+}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5OuterVMn
+// CHECK-SAME:   )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5InnerVMa"([[INT]] %0, %swift.type* [[TYPE:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5InnerVMa"([[INT]] %0, ptr [[TYPE:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* [[TYPE]] to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.+}}$s4main5InnerVMn{{.+}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5InnerVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,19 +6,19 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -34,7 +33,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -42,9 +49,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:    [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,23 +8,23 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1QAAWP", i32 0, i32 0),
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
+// CHECK-SAME:    $sSi4main1QAAWP
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -44,7 +43,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i8**, i8**, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -52,11 +59,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, i8** %2, i8** %3) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2, ptr %3) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TABLE_1:%[0-9]+]] = bitcast i8** %2 to i8*
-// CHECK:   [[ERASED_TABLE_2:%[0-9]+]] = bitcast i8** %3 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE_1]], i8* [[ERASED_TABLE_2]], %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr %3, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,35 +6,35 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySdGMf" = linkonce_odr hidden constant <{
-// CHECk-SAME:    i8**,
+// CHECk-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECk-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi64_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySdGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySdGWV"{{[^,]*}},
 // CHECk-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSdN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSdN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -51,8 +50,24 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySdGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -61,9 +76,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,24 +8,24 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1QAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1RAAWP", i32 0, i32 0),
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
+// CHECK-SAME:    $sSi4main1QAAWP
+// CHECK-SAME:    $sSi4main1RAAWP
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
@@ -48,7 +47,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i8**, i8**, i8**, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -56,9 +63,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_ARGUMENT_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_ARGUMENT_BUFFER]], %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySSGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,39 +22,31 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", i32 0{{(, \[4 x i8\] zeroinitializer)?}}, i64 3 }>, align [[ALIGNMENT]]
+
+// CHECK:      @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
-// CHECK-SAME:    i64
-// CHECK-SAME: }> <{
-//                i8** @"$sBi64_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySdGWV", i32 0, i32 0),
+//                ptr @"$sBi64_WV",
+//                ptr getelementptr inbounds (%swift.vwtable, ptr @"$s4main5ValueVySdGWV", i32 0, i32 0),
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSdN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSdN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
-// CHECK-SAME:    i64
-// CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr getelementptr inbounds (%swift.vwtable, ptr @"$s4main5ValueVySiGWV", i32 0, i32 0),
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -70,9 +61,33 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySdGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySSGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -82,9 +97,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,27 +8,27 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1QAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1RAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1SAAWP", i32 0, i32 0),
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
+// CHECK-SAME:    $sSi4main1QAAWP
+// CHECK-SAME:    $sSi4main1RAAWP
+// CHECK-SAME:    $sSi4main1SAAWP
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -52,7 +51,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i8**, i8**, i8**, i8**, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -60,9 +67,11 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_ARGUMENT_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_ARGUMENT_BUFFER]], %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,55 +6,60 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVys5UInt8VGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi8_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVys5UInt8VGWV", i32 0, i32 0),
+//                ptr @"$sBi8_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVys5UInt8VGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$ss5UInt8VN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $ss5UInt8VN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", i32 0{{(, \[4 x i8\] zeroinitializer)?}}, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
-// CHECK-SAME:   i64
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
+// CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi64_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySdGWV", i32 0, i32 0),
+//                ptr @"$sBi64_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySdGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSdN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSdN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECk-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 struct Value<First> {
@@ -69,10 +73,42 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySdGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySSGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVys5UInt8VGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys5UInt8VGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -83,9 +119,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr {{.+}}$s4main5ValueVMn{{.+}}, 
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,29 +8,29 @@
 // CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_existential_type
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i8**,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECk-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0)
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1QAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1RAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1SAAWP", i32 0, i32 0),
-// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1TAAWP", i32 0, i32 0),
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSi4main1PAAWP
+// CHECK-SAME:    $sSi4main1QAAWP
+// CHECK-SAME:    $sSi4main1RAAWP
+// CHECK-SAME:    $sSi4main1SAAWP
+// CHECK-SAME:    $sSi4main1TAAWP
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -56,7 +55,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i8**, i8**, i8**, i8**, i8**, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -64,9 +71,12 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_ARGUMENT_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_ARGUMENT_BUFFER]], %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:       call swiftcc %swift.metadata_response @swift_getCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -8,48 +7,48 @@
 
 
 // CHECK: @"$s4main5ValueVys4Int8VGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi8_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVys4Int8VGWV", i32 0, i32 0),
+//                ptr @"$sBi8_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVys4Int8VGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$ss4Int8VN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $ss4Int8VN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVys5UInt8VGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi8_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVys5UInt8VGWV", i32 0, i32 0),
+//                ptr @"$sBi8_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVys5UInt8VGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$ss5UInt8VN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $ss5UInt8VN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySSGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -58,39 +57,44 @@
 // NOTE: ignore COMDAT on PE/COFF target
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", i32 0{{(, \[4 x i8\] zeroinitializer)?}}, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVySSGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sBi64_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySdGWV", i32 0, i32 0),
+//                ptr @"$sBi64_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySdGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSdN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSdN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -105,11 +109,51 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySdGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySSGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVys5UInt8VGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVys4Int8VGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys5UInt8VGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys4Int8VGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -121,9 +165,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,23 +6,21 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceC5ValueVySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySS_SiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main9NamespaceC5ValueVySS_SiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceC5ValueVMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main9NamespaceC5ValueVMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -41,21 +38,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceC5ValueVySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -67,18 +53,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.+}}$s4main9NamespaceC5ValueVMn{{.+}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceC5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,23 +6,21 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceO5ValueVySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceO5ValueVySS_SiGWV", i32 0, i32 0)
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main9NamespaceO5ValueVySS_SiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceO5ValueVMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main9NamespaceO5ValueVMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -41,21 +38,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceO5ValueVySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -67,18 +53,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.+}}$s4main9NamespaceO5ValueVMn{{.+}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceO5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,23 +6,21 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceV5ValueVySS_SiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr getelementptr inbounds (%swift.vwtable, ptr @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (
-// CHECK-SAME:      {{.*}}$s4main9NamespaceV5ValueVMn{{.*}} to %swift.type_descriptor*
-// CHECK-SAME:    ),
-// CHECK-SAME:    %swift.type* @"$sSSN",
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main9NamespaceV5ValueVMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -41,21 +38,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceV5ValueVySS_SiGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -67,18 +53,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
 // CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast (
-// CHECK-SAME:       {{.+}}$s4main9NamespaceV5ValueVMn{{.+}} to %swift.type_descriptor*
-// CHECK-SAME:     )
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr %2, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main9NamespaceV5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,27 +6,25 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:   i8**, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   [[INT]], 
-// CHECK-SAME:   %swift.type_descriptor*, 
-// CHECK-SAME:   %swift.type*, 
-// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
+// CHECK-SAME:   ptr, 
 // CHECK-SAME:   i32, 
-// CHECK-SAME:   {{(\[4 x i8\],)?}}
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> <{ 
-//               i8** getelementptr inbounds (
+//               ptr getelementptr inbounds (
 //                 %swift.vwtable, 
-//                 %swift.vwtable* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGWV", 
+//                 ptr @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGWV", 
 //                 i32 0, 
 //                 i32 0
 //               ), 
 // CHECK-SAME:   [[INT]] 512, 
-// CHECK-SAME:   %swift.type_descriptor* bitcast ({{.*}}), 
-// CHECK-SAME:   %swift.type* @"$sSiN", 
-// CHECK-SAME:   %swift.type* @"$sSSN", 
+// CHECK-SAME:   ptr {{[^,]*}}, 
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSSN
 // CHECK-SAME:   i32 0, 
-// CHECK-SAME:   {{(\[4 x i8\] zeroinitializer,)?}}
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, 
 // CHECK-SAME: align [[ALIGNMENT]]
@@ -48,21 +45,10 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{ 
-// CHECK-SAME:           i8**, 
-// CHECK-SAME:           [[INT]], 
-// CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32,
-// CHECK-SAME:           {{(\[4 x i8\],)?}} 
-// CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" 
-// CHECK-SAME:         to %swift.full_type*
-// CHECK-SAME:       ), 
+// CHECK-SAME:       $s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf
 // CHECK-SAME:       i32 0, 
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     )
@@ -74,16 +60,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceVAAq_RszrlE5ValueVMa"([[INT]] %0, %swift.type* [[TYPE_1:%[0-9]+]], %swift.type* [[TYPE_2:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceVAAq_RszrlE5ValueVMa"([[INT]] %0, ptr [[TYPE_1:%[0-9]+]], ptr [[TYPE_2:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* [[TYPE_1]] to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* [[TYPE_2]] to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] %0, 
-// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
-// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
-// CHECK-SAME:     i8* undef, 
-// CHECK-SAME:     %swift.type_descriptor* bitcast ({{[^)]*}})
-// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr [[TYPE_1]], 
+// CHECK-SAME:   ptr [[TYPE_2]], 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr {{[^)]*}}
+// CHECK-SAME: )
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -24,10 +23,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVyS2iGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,7 +22,14 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSiN", %swift.type* @"$sSiN", i32 0, i32 [[ALIGNMENT]], i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 [[ALIGNMENT]], 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 struct Value<First, Second> {
   let first: First
   let second: Second
@@ -36,7 +42,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVyS2iGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVyS2iGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13, second: 13) )
@@ -44,10 +58,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySdSiGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,17 +22,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSdN", %swift.type* @"$sSiN", i32 0, i32 8, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVyS2iGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -42,7 +48,14 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSiN", %swift.type* @"$sSiN", i32 0, i32 [[ALIGNMENT]], i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 [[ALIGNMENT]], 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 struct Value<First, Second> {
   let first: First
   let second: Second
@@ -55,8 +68,24 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVyS2iGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySdSiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVyS2iGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdSiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13, second: 13) )
@@ -65,10 +94,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySSSdGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,17 +22,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySSSdGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", %swift.type* @"$sSdN", i32 0, i32 16, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVySSSdGMf" = linkonce_odr hidden constant <{ 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 16, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdSiGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -42,17 +48,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSdN", %swift.type* @"$sSiN", i32 0, i32 8, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVyS2iGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAMEL    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -61,7 +74,14 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSiN", %swift.type* @"$sSiN", i32 0, i32 [[ALIGNMENT]], i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 [[ALIGNMENT]], 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 struct Value<First, Second> {
   let first: First
   let second: Second
@@ -74,9 +94,33 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVyS2iGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySdSiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySSSdGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVyS2iGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdSiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSSdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13, second: 13) )
@@ -86,10 +130,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVys5UInt8VSSGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,17 +22,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVys5UInt8VSSGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$ss5UInt8VN", %swift.type* @"$sSSN", i32 0, i32 [[ALIGNMENT]], i64 3 }>, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueVys5UInt8VSSGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $ss5UInt8VN
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 [[ALIGNMENT]], 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySSSdGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -42,17 +48,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySSSdGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", %swift.type* @"$sSdN", i32 0, i32 16, i64 3 }>, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueVySSSdGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 16, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdSiGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -61,17 +74,24 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSdN", %swift.type* @"$sSiN", i32 0, i32 8, i64 3 }>, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVyS2iGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -80,7 +100,14 @@
 // NOTE: ignore COMDAT on PE/COFF targets
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant {{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSiN", %swift.type* @"$sSiN", i32 0, i32 [[ALIGNMENT]], i64 3 }>, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 [[ALIGNMENT]], 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 struct Value<First, Second> {
   let first: First
   let second: Second
@@ -93,10 +120,42 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVyS2iGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySdSiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySSSdGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVys5UInt8VSSGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVyS2iGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdSiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSSdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys5UInt8VSSGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13, second: 13) )
@@ -107,10 +166,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVys4Int8Vs5UInt8VGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -24,20 +23,20 @@
 // CHECK-SAME: align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVys4Int8Vs5UInt8VGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:    i8**, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    [[INT]], 
-// CHECK-SAME:    %swift.type_descriptor*, 
-// CHECK-SAME:    %swift.type*, 
-// CHECK-SAME:    %swift.type*, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i64 
 // CHECK-SAME:}> <{ 
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVys4Int8Vs5UInt8VGWV", i32 0, i32 0), 
+// CHECK-SAME:    $s4main5ValueVys4Int8Vs5UInt8VGWV
 // CHECK-SAME:    [[INT]] 512, 
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), 
-// CHECK-SAME:    %swift.type* @"$ss4Int8VN", 
-// CHECK-SAME:    %swift.type* @"$ss5UInt8VN", 
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $ss4Int8VN
+// CHECK-SAME:    $ss5UInt8VN
 // CHECK-SAME:    i32 0, 
 // CHECK-SAME:    i32 1, 
 // CHECK-SAME:    i64 3 
@@ -45,14 +44,14 @@
 
 
 // CHECK: @"$s4main5ValueVys5UInt8VSSGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -62,34 +61,34 @@
 // CHECK-SAME: align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVys5UInt8VSSGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:    i8**, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    [[INT]], 
-// CHECK-SAME:    %swift.type_descriptor*, 
-// CHECK-SAME:    %swift.type*, 
-// CHECK-SAME:    %swift.type*, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i64 
 // CHECK-SAME:}> <{ 
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVys5UInt8VSSGWV", i32 0, i32 0), 
+// CHECK-SAME:    $s4main5ValueVys5UInt8VSSGWV
 // CHECK-SAME:    [[INT]] 512, 
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), 
-// CHECK-SAME:    %swift.type* @"$ss5UInt8VN", 
-// CHECK-SAME:    %swift.type* @"$sSSN", 
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $ss5UInt8VN
+// CHECK-SAME:    $sSSN
 // CHECK-SAME:    i32 0, 
 // CHECK-SAME:    i32 [[ALIGNMENT]], 
 // CHECK-SAME:    i64 3 
 // CHECK-SAME:}>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySSSdGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -99,34 +98,34 @@
 // CHECK-SAME: align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySSSdGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:    i8**, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    [[INT]], 
-// CHECK-SAME:    %swift.type_descriptor*, 
-// CHECK-SAME:    %swift.type*, 
-// CHECK-SAME:    %swift.type*, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i64 
 // CHECK-SAME:}> <{ 
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySSSdGWV", i32 0, i32 0), 
+// CHECK-SAME:    $s4main5ValueVySSSdGWV
 // CHECK-SAME:    [[INT]] 512, 
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), 
-// CHECK-SAME:    %swift.type* @"$sSSN", 
-// CHECK-SAME:    %swift.type* @"$sSdN", 
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSSN
+// CHECK-SAME:    $sSdN
 // CHECK-SAME:    i32 0, 
 // CHECK-SAME:    i32 16, 
 // CHECK-SAME:    i64 3 
 // CHECK-SAME:}>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdSiGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -136,34 +135,34 @@
 // CHECK-SAME: align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVySdSiGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:    i8**, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    [[INT]], 
-// CHECK-SAME:    %swift.type_descriptor*, 
-// CHECK-SAME:    %swift.type*, 
-// CHECK-SAME:    %swift.type*, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i64 
 // CHECK-SAME:}> <{ 
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySdSiGWV", i32 0, i32 0), 
+// CHECK-SAME:    $s4main5ValueVySdSiGWV
 // CHECK-SAME:    [[INT]] 512, 
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), 
-// CHECK-SAME:    %swift.type* @"$sSdN", 
-// CHECK-SAME:    %swift.type* @"$sSiN", 
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSdN
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i32 0, 
 // CHECK-SAME:    i32 8, 
 // CHECK-SAME:    i64 3 
 // CHECK-SAME:}>, align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVyS2iGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main5ValueVwCP
+// CHECK-SAME:    $s4main5ValueVwxx
+// CHECK-SAME:    $s4main5ValueVwcp
+// CHECK-SAME:    $s4main5ValueVwca
+// CHECK-SAME:    $s4main5ValueVwtk
+// CHECK-SAME:    $s4main5ValueVwta
+// CHECK-SAME:    $s4main5ValueVwet
+// CHECK-SAME:    $s4main5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -173,20 +172,20 @@
 // CHECK-SAME: align [[ALIGNMENT]]
 
 // CHECK: @"$s4main5ValueVyS2iGMf" = linkonce_odr hidden constant <{ 
-// CHECK-SAME:    i8**, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    [[INT]], 
-// CHECK-SAME:    %swift.type_descriptor*, 
-// CHECK-SAME:    %swift.type*, 
-// CHECK-SAME:    %swift.type*, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
+// CHECK-SAME:    ptr, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i32, 
 // CHECK-SAME:    i64 
 // CHECK-SAME:}> <{ 
-// CHECK-SAME:    i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVyS2iGWV", i32 0, i32 0), 
+// CHECK-SAME:    $s4main5ValueVyS2iGWV
 // CHECK-SAME:    [[INT]] 512, 
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), 
-// CHECK-SAME:    %swift.type* @"$sSiN", 
-// CHECK-SAME:    %swift.type* @"$sSiN", 
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    $sSiN
 // CHECK-SAME:    i32 0, 
 // CHECK-SAME:    i32 [[ALIGNMENT]], 
 // CHECK-SAME:    i64 3 
@@ -203,11 +202,51 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVyS2iGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySdSiGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVySSSdGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVys5UInt8VSSGMf" to %swift.full_type*), i32 0, i32 2))
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main5ValueVys4Int8Vs5UInt8VGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVyS2iGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySdSiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySSSdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys5UInt8VSSGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVys4Int8Vs5UInt8VGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13, second: 13) )
@@ -219,10 +258,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1, ptr %2) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,14 +6,14 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main9NamespaceC5ValueVySS_SiSdGWV" = linkonce_odr hidden constant %swift.vwtable {
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwCP{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwxx{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwcp{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwca{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwtk{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwta{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwet{{[^)]*}} to i8*)
-// CHECK-SAME:    i8* bitcast ({{[^@]+}}@"$s4main9NamespaceC5ValueVwst{{[^)]*}} to i8*)
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwCP
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwxx
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwcp
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwca
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwtk
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwta
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwet
+// CHECK-SAME:    $s4main9NamespaceC5ValueVwst
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    [[INT]] {{[0-9]+}},
 // CHECK-SAME:    i32 {{[0-9]+}},
@@ -23,7 +22,15 @@
 // NOTE: ignore the COMDAT on PE/COFF platforms
 // CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main9NamespaceC5ValueVySS_SiSdGMf" = linkonce_odr hidden constant {{.+}}$s4main9NamespaceC5ValueVMn{{.+}} to %swift.type_descriptor*), %swift.type* @"$sSSN", %swift.type* @"$sSiN", %swift.type* @"$sSdN", i32 0, i32 8, i64 3 }>, align [[ALIGNMENT]]
+// CHECK:      @"$s4main9NamespaceC5ValueVySS_SiSdGMf" = linkonce_odr hidden constant <{
+// CHECK-SAME:   $s4main9NamespaceC5ValueVMn
+// CHECK-SAME:   $sSSN
+// CHECK-SAME:   $sSiN
+// CHECK-SAME:   $sSdN
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   i32 8, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 final class Namespace<Arg> {
   struct Value<First, Second> {
     let first: First
@@ -38,7 +45,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, %swift.type*, i32, i32, i64 }>* @"$s4main9NamespaceC5ValueVySS_SiSdGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main9NamespaceC5ValueVySS_SiSdGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Namespace<String>.Value(first: 13, second: 13.0) )
@@ -46,11 +61,14 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2, %swift.type* %3) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, ptr %1, ptr %2, ptr %3) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK: entry:
-// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
-// CHECK:   [[ERASED_TYPE_3:%[0-9]+]] = bitcast %swift.type* %3 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* [[ERASED_TYPE_3]], %swift.type_descriptor* bitcast ({{.+}}$s4main9NamespaceC5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main9NamespaceC5ValueVMz") #{{[0-9]+}}
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr %2, 
+// CHECK-SAME:   ptr %3, 
+// CHECK-SAME:   $s4main9NamespaceC5ValueVMn
+// CHECK-SAME:   $s4main9NamespaceC5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,17 +8,17 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03OneA0Vy4main03TheA0VGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
+//           :     
 // CHECK-SAME:       $s8Argument03OneA0Vy4main03TheA0VGWV
 //           :     ",
 //           :     i32 0,
@@ -27,49 +26,7 @@
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
 // CHECK-SAME:   $s8Argument03OneA0VMn
-// CHECK-SAME:   %swift.type* bitcast (
-// CHECK-SAME:     [[INT]]* getelementptr inbounds (
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>,
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8*,
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>* @"$s4main11TheArgumentVMf",
-// CHECK-SAME:       i32 0,
-// CHECK-SAME:       i32 2
-// CHECK-SAME:     ) to %swift.type*
-// CHECK-SAME:   ),
+// CHECK-SAME:   $s4main11TheArgumentVMf
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{8|4}},
 // TRAILING FLAGS: ...01
@@ -94,29 +51,18 @@ struct TheArgument {
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03OneA0Vy4main03TheA0VGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03OneA0Vy4main03TheA0VGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:     %swift.type** @"$s8Argument03OneA0Vy4main03TheA0VGMJ"
+// CHECK-SAME:     $s8Argument03OneA0Vy4main03TheA0VGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument.swift -emit-library -o %t/%target-library-name(Generic) -emit-module -module-name Generic -emit-module-path %t/Generic.swiftmodule
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,27 +9,25 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:  %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
+//           :     
 // CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGWV
 //           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s7Generic11OneArgumentVMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   $s8Argument7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -49,29 +46,17 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVy0C07IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s7Generic11OneArgumentVy0C07IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVy0C07IntegerVGMJ"
-// CHECK-SAME:   )
+// CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGMJ
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument.swift %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,27 +8,23 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
 // CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
-//           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s8Argument03OneA0VMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   $s8Argument7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -47,29 +42,17 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03OneA0VyAA7IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
-// CHECK-SAME:   )
+// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGMJ
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument-1constraint.swift %S/Inputs/protocol-public-empty.swift %S/Inputs/struct-public-nonfrozen-0argument.swift %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,29 +8,26 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
+//           :     
 // CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
-//           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s8Argument03OneA0VMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
-// CHECK-SAME:   i8** @"$s8Argument7IntegerVAA1PAAWP",
+// CHECK-SAME:   $s8Argument7IntegerVN
+// CHECK-SAME:   $s8Argument7IntegerVAA1PAAWP
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -49,29 +45,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03OneA0VyAA7IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
+// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument-1constraint.swift %S/Inputs/protocol-public-empty.swift %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Module) -emit-module -module-name Module -emit-module-path %t/Module.swiftmodule
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule -DIMPORT_MODULE -L %t -I %t -lModule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lModule -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lModule -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lModule -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,29 +9,20 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:  i8**,
+// CHECK-SAME:  ptr,
 // CHECK-SAME:  [[INT]],
-// CHECK-SAME:  %swift.type_descriptor*,
-// CHECK-SAME:  %swift.type*,
-// CHECK-SAME:  i8**,
+// CHECK-SAME:  ptr,
+// CHECK-SAME:  ptr,
+// CHECK-SAME:  ptr,
 // CHECK-SAME:  i32,
 // CHECK-SAME:  i32,
 // CHECK-SAME:  i64
 // CHECK-SAME:}> <{
-//           :  i8** getelementptr inbounds (
-//           :    %swift.vwtable,
-//           :    %swift.vwtable* @"
-// CHECK-SAME:    $s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GWV
-//           :    ",
-//           :    i32 0,
-//           :    i32 0
-//           :  ),
+// CHECK-SAME:  $s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GWV
 // CHECK-SAME:  [[INT]] 512,
-//           :  %swift.type_descriptor* @"
 // CHECK-SAME:  $s6Module11OneArgumentVMn
-//           :  ",
-// CHECK-SAME:  %swift.type* @"$s6Module7IntegerVN",
-// CHECK-SAME:  i8** @"$s6Module7IntegerVAA1P8ArgumentWP",
+// CHECK-SAME:  $s6Module7IntegerVN
+// CHECK-SAME:  $s6Module7IntegerVAA1P8ArgumentWP
 // CHECK-SAME:  i32 0,
 // CHECK-SAME:  i32 {{4|8}},
 // CHECK-SAME:  i64 1
@@ -51,29 +41,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMJ"
+// CHECK-SAME:     $s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument-1constraint.swift %S/Inputs/protocol-public-empty.swift %S/Inputs/struct-public-nonfrozen-0argument.swift %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,29 +8,20 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
-//           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
-// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
-//           :     ",
-//           :     i32 0,
-//           :     i32 0
-//           :   ),
+// CHECK-SAME:   $s8Argument03OneA0VyAA7IntegerVGWV
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s8Argument03OneA0VMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
-// CHECK-SAME:   i8** @"$s8Argument7IntegerVAA1PAAWP",
+// CHECK-SAME:   $s8Argument7IntegerVN
+// CHECK-SAME:   $s8Argument7IntegerVAA1PAAWP
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -49,29 +39,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03OneA0VyAA7IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
+// CHECK-SAME:   $s8Argument03OneA0VyAA7IntegerVGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-1argument-1constraint.swift %S/Inputs/struct-public-nonfrozen-0argument.swift %S/Inputs/protocol-public-empty.swift -emit-library -o %t/%target-library-name(Module) -emit-module -module-name Module -emit-module-path %t/Module.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s %S/Inputs/main.swift %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -module-name main -L %t -I %t -lModule -DIMPORT_MODULE | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s %S/Inputs/main.swift %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -module-name main -L %t -I %t -lModule -DIMPORT_MODULE
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s %S/Inputs/main.swift %S/Inputs/struct-public-nonfrozen-0argument-conformance-empty.swift -module-name main -L %t -I %t -lModule -DIMPORT_MODULE | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,36 +8,25 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
-// CHECK-SAME:       $s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GWV
-//           :     ",
+// CHECK-SAME:     $s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GWV
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
 // CHECK-SAME:   $s6Module11OneArgumentVMn
-// CHECK-SAME:   %swift.type* @"$s6Module7IntegerVN",
-// CHECK-SAME:   i8** getelementptr inbounds (
-// CHECK-SAME:     [
-// CHECK-SAME:       1 x i8*
-// CHECK-SAME:     ],
-// CHECK-SAME:     [
-// CHECK-SAME:       1 x i8*
-// CHECK-SAME:     ]* @"$s6Module7IntegerVAA1P4mainWP",
-// CHECK-SAME:     i32 0,
-// CHECK-SAME:     i32 0
-// CHECK-SAME:   ),
+// CHECK-SAME:   $s6Module7IntegerVN
+// CHECK-SAME:   $s6Module7IntegerVAA1P4mainWP
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{8|4}},
 // CHECK-SAME:   i64 1
@@ -62,30 +50,18 @@ struct AnotherArgument {
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0,
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:     %swift.type** @"$s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMJ"
+// CHECK-SAME:     $s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-2argument.swift %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Module) -emit-module -module-name Module -emit-module-path %t/Module.swiftmodule
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,39 +9,24 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
-//           :   [
-//           :     4 x i8
-//           :   ],
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
-//           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
-// CHECK-SAME:     $s6Module11TwoArgumentVyAA7IntegerV0C0ADVGWV
-//           :     ",
-//           :     i32 0,
-//           :     i32 0
-//           :   ),
+// CHECK-SAME:   $s6Module11TwoArgumentVyAA7IntegerV0C0ADVGWV
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s6Module11TwoArgumentVMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s6Module7IntegerVN",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   $s6Module7IntegerVN
+// CHECK-SAME:   $s8Argument7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i32 {{8|16}},
-//           :   [
-//           :     4 x i8
-//           :   ] zeroinitializer,
 // CHECK-SAME:   i64 1
 // CHECK-SAME: }>,
 // CHECK-SAME: align [[ALIGNMENT]]
@@ -59,29 +43,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMJ"
+// CHECK-SAME:   $s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-nonfrozen-2argument.swift %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,39 +8,29 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s8Argument03TwoA0VyAA7IntegerVAEGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
-//           :   [
-//           :     4 x i8
-//           :   ],
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
 // CHECK-SAME:     $s8Argument03TwoA0VyAA7IntegerVAEGWV
-//           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s8Argument03TwoA0VMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   $s8Argument7IntegerVN
+// CHECK-SAME:   $s8Argument7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i32 {{8|16}},
-//           :   [
-//           :     4 x i8
-//           :   ] zeroinitializer,
 // CHECK-SAME:   i64 1
 // CHECK-SAME: }>,
 // CHECK-SAME: align [[ALIGNMENT]]
@@ -57,29 +46,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s8Argument03TwoA0VyAA7IntegerVAEGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s8Argument03TwoA0VyAA7IntegerVAEGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s8Argument03TwoA0VyAA7IntegerVAEGMJ"
+// CHECK-SAME:   $s8Argument03TwoA0VyAA7IntegerVAEGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-frozen-1argument.swift -emit-library -o %t/%target-library-name(Generic) -emit-module -module-name Generic -emit-module-path %t/Generic.swiftmodule -enable-library-evolution
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,67 +8,23 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s7Generic11OneArgumentVy4main03TheC0VGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
-// CHECK-SAME:       $s7Generic11OneArgumentVy4main03TheC0VGWV
-//           :     ",
+// CHECK-SAME:     $s7Generic11OneArgumentVy4main03TheC0VGWV
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
 // CHECK-SAME:   $s7Generic11OneArgumentVMn
-// CHECK-SAME:   %swift.type* bitcast (
-// CHECK-SAME:     [[INT]]* getelementptr inbounds (
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>,
-// CHECK-SAME:       <{
-// CHECK-SAME:         i8*,
-// CHECK-SAME:         i8**,
-// CHECK-SAME:         [[INT]],
-// CHECK-SAME:         <{
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32
-// CHECK-SAME:         }>*,
-// CHECK-SAME:         i32,
-//           :         [
-//           :           4 x i8
-//           :         ],
-// CHECK-SAME:         i64
-// CHECK-SAME:       }>* @"$s4main11TheArgumentVMf",
-// CHECK-SAME:       i32 0,
-// CHECK-SAME:       i32 2
-// CHECK-SAME:     ) to %swift.type*
-// CHECK-SAME:   ),
+// CHECK-SAME:   $s4main11TheArgumentVMf
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{8|4}},
 // TRAILING FLAGS: ...01
@@ -94,29 +49,18 @@ struct TheArgument {
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVy4main03TheC0VGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s7Generic11OneArgumentVy4main03TheC0VGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVy4main03TheC0VGMJ"
+// CHECK-SAME:   $s7Generic11OneArgumentVy4main03TheC0VGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-frozen-1argument.swift -emit-library -o %t/%target-library-name(Generic) -emit-module -module-name Generic -emit-module-path %t/Generic.swiftmodule -enable-library-evolution
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-frozen-0argument.swift -emit-library -o %t/%target-library-name(Argument) -emit-module -module-name Argument -emit-module-path %t/Argument.swiftmodule -enable-library-evolution
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric -lArgument | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -10,27 +9,23 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
 // CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGWV
-//           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s7Generic11OneArgumentVMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   $s8Argument7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -49,29 +44,18 @@ import Argument
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVy0C07IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s7Generic11OneArgumentVy0C07IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVy0C07IntegerVGMJ"
+// CHECK-SAME:   $s7Generic11OneArgumentVy0C07IntegerVGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -prespecialize-generic-metadata -target %module-target-future %S/Inputs/struct-public-frozen-1argument.swift %S/Inputs/struct-public-frozen-0argument.swift -emit-library -o %t/%target-library-name(Generic) -emit-module -module-name Generic -emit-module-path %t/Generic.swiftmodule -enable-library-evolution
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -L %t -I %t -lGeneric | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment 
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -9,27 +8,23 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 //      CHECK: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" = linkonce_odr hidden constant <{
-// CHECK-SAME:   i8**,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   [[INT]],
-// CHECK-SAME:   %swift.type_descriptor*,
-// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   ptr,
+// CHECK-SAME:   ptr,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i32,
 // CHECK-SAME:   i64
 // CHECK-SAME: }> <{
-//           :   i8** getelementptr inbounds (
+//           :   ptr getelementptr inbounds (
 //           :     %swift.vwtable,
-//           :     %swift.vwtable* @"
 // CHECK-SAME:     $s7Generic11OneArgumentVyAA7IntegerVGWV
-//           :     ",
 //           :     i32 0,
 //           :     i32 0
 //           :   ),
 // CHECK-SAME:   [[INT]] 512,
-//           :   %swift.type_descriptor* @"
 // CHECK-SAME:   $s7Generic11OneArgumentVMn
-//           :   ",
-// CHECK-SAME:   %swift.type* @"$s7Generic7IntegerVN",
+// CHECK-SAME:   $s7Generic7IntegerVN
 // CHECK-SAME:   i32 0,
 // CHECK-SAME:   i32 {{4|8}},
 // CHECK-SAME:   i64 1
@@ -47,29 +42,18 @@ import Generic
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
 // CHECK-SAME:     [[INT]] 0, 
-// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type,
-// CHECK-SAME:       %swift.full_type* bitcast (
-// CHECK-SAME:         <{
-// CHECK-SAME:           i8*,
-// CHECK-SAME:           i8**,
-// CHECK-SAME:           [[INT]],
-// CHECK-SAME:           %swift.type_descriptor*,
-// CHECK-SAME:           %swift.type*,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i32,
-// CHECK-SAME:           i64
-// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVyAA7IntegerVGMN" to %swift.full_type*
-// CHECK-SAME:       ),
+// CHECK-SAME:       $s7Generic11OneArgumentVyAA7IntegerVGMN
 // CHECK-SAME:       i32 0,
 // CHECK-SAME:       i32 2
 // CHECK-SAME:     ),
-// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVyAA7IntegerVGMJ"
+// CHECK-SAME:   $s7Generic11OneArgumentVyAA7IntegerVGMJ
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
-// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,4 @@
-// RUN: %swift %use_no_opaque_pointers -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
-// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
@@ -7,19 +6,19 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK: @"$s4main5ValueVySiGMf" = linkonce_odr hidden constant <{
-// CHECK-SAME:    i8**,
+// CHECK-SAME:    ptr,
 // CHECK-SAME:    [[INT]],
-// CHECK-SAME:    %swift.type_descriptor*,
-// CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    ptr,
+// CHECK-SAME:    i32,
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main5ValueVySiGWV", i32 0, i32 0),
+//                ptr @"$sB[[INT]]_WV",
+//                ptr {{[^@]*}}@"$s4main5ValueVySiGWV"{{[^,]*}},
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*),
-// CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
+// CHECK-SAME:    $s4main5ValueVMn
+// CHECK-SAME:    $sSiN
+// CHECK-SAME:    i32 0,
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
@@ -35,7 +34,15 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8*, i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main5ValueVySiGMf" to %swift.full_type*), i32 0, i32 2))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     $s4main5ValueVySiGMf
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 2
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Value(first: 13) )
@@ -43,9 +50,13 @@ func doit() {
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define{{( protected| dllexport)?}} swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK: entry:
-// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast ({{.+}}$s4main5ValueVMn{{.+}} to %swift.type_descriptor*), [[INT]]* @"$s4main5ValueVMz") #{{[0-9]+}}
+// CHECK: define{{( protected| dllexport)?}} swiftcc %swift.metadata_response @"$s4main5ValueVMa"([[INT]] %0, ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK:      call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   ptr %1, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   ptr undef, 
+// CHECK-SAME:   $s4main5ValueVMn
+// CHECK-SAME:   $s4main5ValueVMz
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }


### PR DESCRIPTION
Made the following changes:
- migrated to opaque pointers
- replaced some long lines with CHECK-SAME lines
- replaced direct hard references like @"foo" with foo, making arm64e matching easier